### PR TITLE
Add COMMENT_TITLE env var for issue comment title

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ The `if: always()` clause guarantees that this action always runs, even if earli
 The job name in the GitHub Actions section that provides the test results can be configured via the
 `check_name` variable. It is optional and defaults to `"Unit Test Results"`, as shown in above screenshot.
 
+The comment title in the Pull request **Conversation** tab that shows test results can also be configured via the `comment_title` variable.
+It is optional and defaults to the `check_name` variable.
+
 Files can be selected via the `files` variable, which is optional and defaults to the current working directory.
 It supports wildcards like `*`, `**`, `?` and `[]`. The `**` wildcard matches
 [directories recursively](https://docs.python.org/3/library/pathlib.html#pathlib.Path.glob): `./`, `./*/`, `./*/*/`, etc.

--- a/publish_unit_test_results.py
+++ b/publish_unit_test_results.py
@@ -290,7 +290,7 @@ def get_stats_from_digest(digest: str) -> Dict[Any, Any]:
     return json.loads(ungest_string(digest))
 
 
-def get_short_summary(stats: Dict[str, Any]) -> str:
+def get_short_summary(stats: Dict[str, Any], check_name='Unit Test Results') -> str:
     """Provides a single-line summary for the given stats."""
     default = check_name
     if stats is None:
@@ -604,7 +604,7 @@ def publish(token: str, event: dict, repo_name: str, commit_sha: str,
         all_annotations = [all_annotations[x:x+50] for x in range(0, len(all_annotations), 50)] or [[]]
         for annotations in all_annotations:
             output = dict(
-                title=get_short_summary(stats),
+                title=get_short_summary(stats, check_name),
                 summary=get_long_summary_with_digest_md(stats_with_delta, stats),
                 annotations=annotations
             )

--- a/publish_unit_test_results.py
+++ b/publish_unit_test_results.py
@@ -292,7 +292,7 @@ def get_stats_from_digest(digest: str) -> Dict[Any, Any]:
 
 def get_short_summary(stats: Dict[str, Any]) -> str:
     """Provides a single-line summary for the given stats."""
-    default = 'Unit Test Results'
+    default = check_name
     if stats is None:
         return default
 
@@ -626,7 +626,7 @@ def publish(token: str, event: dict, repo_name: str, commit_sha: str,
             return pull
 
         logger.info('creating comment')
-        pull.create_issue_comment('## Unit Test Results\n{}'.format(get_long_summary_md(stats_with_delta)))
+        pull.create_issue_comment('## {}\n{}'.format(check_name, get_long_summary_md(stats_with_delta)))
         return pull
 
     def hide_comments(pull: PullRequest) -> None:
@@ -693,7 +693,7 @@ def publish(token: str, event: dict, repo_name: str, commit_sha: str,
         comments = list([comment for comment in comments
                          if comment.get('author', {}).get('login') == 'github-actions'
                          and comment.get('isMinimized') is False
-                         and comment.get('body', '').startswith('## Unit Test Results\n')
+                         and comment.get('body', '').startswith('## {}\n'.format(check_name))
                          and '\nresults for commit ' in comment.get('body')])
 
         # get comment node ids and their commit sha (possibly abbreviated)

--- a/publish_unit_test_results.py
+++ b/publish_unit_test_results.py
@@ -508,7 +508,7 @@ def get_annotations(case_results: Dict[str, Dict[str, List[Dict[Any, Any]]]], re
 
 def publish(token: str, event: dict, repo_name: str, commit_sha: str,
             stats: Dict[Any, Any], cases: Dict[str, Dict[str, List[Dict[Any, Any]]]],
-            comment_title: str, check_name: str, report_individual_runs: bool):
+            check_name: str, comment_title: str, report_individual_runs: bool):
     from github import Github, PullRequest, Requester, MainClass
     from githubext import Repository, Commit, IssueComment
 
@@ -735,7 +735,7 @@ def write_stats_file(stats, filename) -> None:
         f.write(json.dumps(stats))
 
 
-def main(token: str, event: dict, repo: str, commit: str, files_glob: str, comment_title: str, check_name: str,
+def main(token: str, event: dict, repo: str, commit: str, files_glob: str, check_name: str, comment_title: str,
          report_individual_runs: bool, dedup_classes_by_file_name: bool) -> None:
     files = [str(file) for file in pathlib.Path().glob(files_glob)]
     logger.info('reading {}: {}'.format(files_glob, list(files)))
@@ -751,7 +751,7 @@ def main(token: str, event: dict, repo: str, commit: str, files_glob: str, comme
     stats = get_stats(results)
 
     # publish the delta stats
-    publish(token, event, repo, commit, stats, results['case_results'], comment_title, check_name, report_individual_runs)
+    publish(token, event, repo, commit, stats, results['case_results'], check_name, comment_title, report_individual_runs)
 
 
 def get_commit_sha(event: dict, event_name: str):
@@ -799,4 +799,4 @@ if __name__ == "__main__":
     check_var(commit, 'COMMIT or event file', 'Commit SHA')
     check_var(files, 'FILES', 'Files pattern')
 
-    main(token, event, repo, commit, files, comment_title, check_name, report_individual_runs, dedup_classes_by_file_name)
+    main(token, event, repo, commit, files, check_name, comment_title, report_individual_runs, dedup_classes_by_file_name)

--- a/publish_unit_test_results.py
+++ b/publish_unit_test_results.py
@@ -693,7 +693,7 @@ def publish(token: str, event: dict, repo_name: str, commit_sha: str,
         comments = list([comment for comment in comments
                          if comment.get('author', {}).get('login') == 'github-actions'
                          and comment.get('isMinimized') is False
-                         and comment.get('body', '').startswith('## {}\n'.format(check_name))
+                         and comment.get('body', '').startswith('## {}\n'.format(comment_title))
                          and '\nresults for commit ' in comment.get('body')])
 
         # get comment node ids and their commit sha (possibly abbreviated)

--- a/publish_unit_test_results.py
+++ b/publish_unit_test_results.py
@@ -508,7 +508,7 @@ def get_annotations(case_results: Dict[str, Dict[str, List[Dict[Any, Any]]]], re
 
 def publish(token: str, event: dict, repo_name: str, commit_sha: str,
             stats: Dict[Any, Any], cases: Dict[str, Dict[str, List[Dict[Any, Any]]]],
-            check_name: str, report_individual_runs: bool):
+            issue_comment_title: str, check_name: str, report_individual_runs: bool):
     from github import Github, PullRequest, Requester, MainClass
     from githubext import Repository, Commit, IssueComment
 
@@ -612,7 +612,7 @@ def publish(token: str, event: dict, repo_name: str, commit_sha: str,
             logger.info('creating check')
             repo.create_check_run(name=check_name, head_sha=commit_sha, status='completed', conclusion='success', output=output)
 
-    def publish_comment(stats: Dict[Any, Any], pull) -> None:
+    def publish_comment(title: str, stats: Dict[Any, Any], pull) -> None:
         # compare them with earlier stats
         base_commit_sha = pull.base.sha if pull else None
         logger.debug('comparing against base={}'.format(base_commit_sha))
@@ -626,7 +626,7 @@ def publish(token: str, event: dict, repo_name: str, commit_sha: str,
             return pull
 
         logger.info('creating comment')
-        pull.create_issue_comment('## {}\n{}'.format(check_name, get_long_summary_md(stats_with_delta)))
+        pull.create_issue_comment('## {}\n{}'.format(title, get_long_summary_md(stats_with_delta)))
         return pull
 
     def hide_comments(pull: PullRequest) -> None:
@@ -723,7 +723,7 @@ def publish(token: str, event: dict, repo_name: str, commit_sha: str,
 
     pull = get_pull(commit_sha)
     if pull is not None:
-        publish_comment(stats, pull)
+        publish_comment(issue_comment_title, stats, pull)
         hide_comments(pull)
     else:
         logger.info('there is no pull request for commit {}'.format(commit_sha))
@@ -735,7 +735,7 @@ def write_stats_file(stats, filename) -> None:
         f.write(json.dumps(stats))
 
 
-def main(token: str, event: dict, repo: str, commit: str, files_glob: str, check_name: str,
+def main(token: str, event: dict, repo: str, commit: str, files_glob: str, issue_comment_title: str, check_name: str,
          report_individual_runs: bool, dedup_classes_by_file_name: bool) -> None:
     files = [str(file) for file in pathlib.Path().glob(files_glob)]
     logger.info('reading {}: {}'.format(files_glob, list(files)))
@@ -751,7 +751,7 @@ def main(token: str, event: dict, repo: str, commit: str, files_glob: str, check
     stats = get_stats(results)
 
     # publish the delta stats
-    publish(token, event, repo, commit, stats, results['case_results'], check_name, report_individual_runs)
+    publish(token, event, repo, commit, stats, results['case_results'], issue_comment_title, check_name, report_individual_runs)
 
 
 def get_commit_sha(event: dict, event_name: str):
@@ -788,6 +788,7 @@ if __name__ == "__main__":
     token = get_var('GITHUB_TOKEN')
     repo = get_var('GITHUB_REPOSITORY')
     check_name = get_var('CHECK_NAME') or 'Unit Test Results'
+    comment_title = get_var('COMMENT_TITLE') or check_name
     report_individual_runs = get_var('REPORT_INDIVIDUAL_RUNS') == 'true'
     dedup_classes_by_file_name = get_var('DEDUPLICATE_CLASSES_BY_FILE_NAME') == 'true'
     commit = get_var('COMMIT') or get_commit_sha(event, event_name)
@@ -798,4 +799,4 @@ if __name__ == "__main__":
     check_var(commit, 'COMMIT or event file', 'Commit SHA')
     check_var(files, 'FILES', 'Files pattern')
 
-    main(token, event, repo, commit, files, check_name, report_individual_runs, dedup_classes_by_file_name)
+    main(token, event, repo, commit, files, comment_title, check_name, report_individual_runs, dedup_classes_by_file_name)

--- a/publish_unit_test_results.py
+++ b/publish_unit_test_results.py
@@ -508,7 +508,7 @@ def get_annotations(case_results: Dict[str, Dict[str, List[Dict[Any, Any]]]], re
 
 def publish(token: str, event: dict, repo_name: str, commit_sha: str,
             stats: Dict[Any, Any], cases: Dict[str, Dict[str, List[Dict[Any, Any]]]],
-            issue_comment_title: str, check_name: str, report_individual_runs: bool):
+            comment_title: str, check_name: str, report_individual_runs: bool):
     from github import Github, PullRequest, Requester, MainClass
     from githubext import Repository, Commit, IssueComment
 
@@ -723,7 +723,7 @@ def publish(token: str, event: dict, repo_name: str, commit_sha: str,
 
     pull = get_pull(commit_sha)
     if pull is not None:
-        publish_comment(issue_comment_title, stats, pull)
+        publish_comment(comment_title, stats, pull)
         hide_comments(pull)
     else:
         logger.info('there is no pull request for commit {}'.format(commit_sha))
@@ -735,7 +735,7 @@ def write_stats_file(stats, filename) -> None:
         f.write(json.dumps(stats))
 
 
-def main(token: str, event: dict, repo: str, commit: str, files_glob: str, issue_comment_title: str, check_name: str,
+def main(token: str, event: dict, repo: str, commit: str, files_glob: str, comment_title: str, check_name: str,
          report_individual_runs: bool, dedup_classes_by_file_name: bool) -> None:
     files = [str(file) for file in pathlib.Path().glob(files_glob)]
     logger.info('reading {}: {}'.format(files_glob, list(files)))
@@ -751,7 +751,7 @@ def main(token: str, event: dict, repo: str, commit: str, files_glob: str, issue
     stats = get_stats(results)
 
     # publish the delta stats
-    publish(token, event, repo, commit, stats, results['case_results'], issue_comment_title, check_name, report_individual_runs)
+    publish(token, event, repo, commit, stats, results['case_results'], comment_title, check_name, report_individual_runs)
 
 
 def get_commit_sha(event: dict, event_name: str):


### PR DESCRIPTION
This PR allows hard coded issue comment title `Unit Test Results` to be changed when `COMMENT_TITLE` env var is defined.