### PR TITLE
Add support for workflow_dispatch event name

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ also compares unit test results across commits. This allows seeing changes in th
 
 ## Using this Action
 
-You can add this action to your GitHub workflow on `push`, `pull_request`, and `pull_request_target` events
-and configure it as follows:
+You can add this action to your GitHub workflow on `push`, `pull_request`, `pull_request_target` 
+and `workflow_dispatch` events and configure it as follows:
 
 ```yaml
 - name: Publish Unit Test Results

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ also compares unit test results across commits. This allows seeing changes in th
 
 ## Using this Action
 
-You can add this action to your GitHub workflow on `push`, `pull_request`, `pull_request_target` 
-and `workflow_dispatch` events and configure it as follows:
+You can add this action to your GitHub workflow on `push`, `pull_request`, `pull_request_target` and 
+`workflow_dispatch` events and configure it as follows:
 
 ```yaml
 - name: Publish Unit Test Results

--- a/publish_unit_test_results.py
+++ b/publish_unit_test_results.py
@@ -804,7 +804,7 @@ def main(token: str, event: dict, repo: str, commit: str, files_glob: str,
 def get_commit_sha(event: dict, event_name: str):
     logger.debug("action triggered by '{}' event".format(event_name))
 
-    if event_name == 'push' or event_name == 'workflow_dispatch':
+    if event_name in ['push', 'workflow_dispatch']:
         return os.environ.get('GITHUB_SHA')
     elif event_name in ['pull_request', 'pull_request_target']:
         return event.get('pull_request', {}).get('head', {}).get('sha')

--- a/publish_unit_test_results.py
+++ b/publish_unit_test_results.py
@@ -804,7 +804,7 @@ def main(token: str, event: dict, repo: str, commit: str, files_glob: str,
 def get_commit_sha(event: dict, event_name: str):
     logger.debug("action triggered by '{}' event".format(event_name))
 
-    if event_name == 'push':
+    if event_name == 'push' or event_name == 'workflow_dispatch':
         return os.environ.get('GITHUB_SHA')
     elif event_name in ['pull_request', 'pull_request_target']:
         return event.get('pull_request', {}).get('head', {}).get('sha')


### PR DESCRIPTION
Manually triggered event are not supported: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#manual-events.

If the `workflow_dispatch` event name is used, the action will raise this error: `RuntimeError("event '{}' is not supported".format(event))`.

Add support for `workflow_dispatch` event name.