### PR TITLE
Test list annotations only on default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,14 @@ If multiple runs exist for a test, only the first failure is reported, unless `r
 In the rare situation where a project contains test class duplicates with the same name in different files,
 you may want to set `deduplicate_classes_by_file_name` to `true`.
 
-The check run provides more information than the test failures. With `check_run_annotations`, additional information
-can be displayed. Use comma to set multiple values:
+With `check_run_annotations`, the check run provides additional information.
+Use comma to set multiple values:
 
 - All found tests are displayed with `all tests`.
 - All skipped tests are listed with `skipped tests`.
+
+These additional information are only added to the default branch of your repository, e.g. `main` or `master`.
+Use `check_run_annotations_branch` to enable this for multiple branches (comma separated list) or all branches (`"*"`).
 
 See this complete list of configuration options for reference:
 ```yaml
@@ -127,6 +130,7 @@ See this complete list of configuration options for reference:
     files: test-results/**/*.xml
     report_individual_runs: true
     deduplicate_classes_by_file_name: false
+    check_run_annotations_branch: main, master, branch_one
     check_run_annotations: all tests, skipped tests
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ inputs:
     required: false
     default: 'all tests, skipped tests'
   check_run_annotations_branch:
-    description: 'Adds check run annotations only on given branches. If not given, this defaults to the default branch of your repository, e.g. main or master. Comma separated list of branch names allowed, asterisk (*) matches all branches.'
+    description: 'Adds check run annotations only on given branches. If not given, this defaults to the default branch of your repository, e.g. main or master. Comma separated list of branch names allowed, asterisk "*" matches all branches.'
     required: false
   log_level:
     description: 'Action logging level'

--- a/action.yml
+++ b/action.yml
@@ -33,9 +33,12 @@ inputs:
     required: false
     default: 'true'
   check_run_annotations:
-    description: 'Adds additional information to the check run (comma-separated list): all tests - list all found tests, skipped tests - list all skipped tests'
+    description: 'Adds additional information to the check run (comma-separated list): all tests - list all found tests, skipped tests - list all skipped tests, none - no extra annotations at all'
     required: false
     default: 'all tests, skipped tests'
+  check_run_annotations_branch:
+    description: 'Adds check run annotations only on given branches. If not given, this defaults to the default branch of your repository, e.g. main or master. Comma separated list of branch names allowed, asterisk (*) matches all branches.'
+    required: false
   log_level:
     description: 'Action logging level'
     required: false

--- a/publish/__init__.py
+++ b/publish/__init__.py
@@ -39,7 +39,9 @@ hide_comments_modes = [
 
 all_tests_list = 'all tests'
 skipped_tests_list = 'skipped tests'
-available_annotations = [all_tests_list, skipped_tests_list]
+none_list = 'none'
+available_annotations = [all_tests_list, skipped_tests_list, none_list]
+default_annotations = [all_tests_list, skipped_tests_list]
 
 
 def utf8_character_length(c: int) -> int:

--- a/publish_unit_test_results.py
+++ b/publish_unit_test_results.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Union
 import github
 
 from junit import parse_junit_xml_files
-from publish import hide_comments_modes, available_annotations
+from publish import hide_comments_modes, available_annotations, default_annotations
 from publish.publisher import Publisher, Settings
 from unittestresults import get_test_results, get_stats, ParsedUnitTestResults
 from github_action import GithubAction
@@ -66,6 +66,26 @@ def get_commit_sha(event: dict, event_name: str):
     return os.environ.get('GITHUB_SHA')
 
 
+def get_annotations_config(event: Optional[dict]) -> List[str]:
+    annotations = get_var('CHECK_RUN_ANNOTATIONS')
+    annotations = [annotation.strip() for annotation in annotations.split(',')] \
+        if annotations else default_annotations
+    default_branch = event.get('repository', {}).get('default_branch') if event else None
+    annotations_branch = get_var('CHECK_RUN_ANNOTATIONS_BRANCH') or default_branch or 'main, master'
+    annotations_branches = {branch.strip() for branch in annotations_branch.split(',')}
+    branch = get_var('GITHUB_REF')
+
+    if annotations and branch and annotations_branches and \
+            '*' not in annotations_branches and \
+            branch not in annotations_branches:
+        branches = "', '".join(annotations_branches)
+        logger.info(f"Current branch '{branch}' not among branches '{branches}', "
+                    f"will not add annotations to the check run.")
+        annotations = []
+
+    return annotations
+
+
 if __name__ == "__main__":
     def get_var(name: str) -> str:
         return os.environ.get('INPUT_{}'.format(name)) or os.environ.get(name)
@@ -100,9 +120,8 @@ if __name__ == "__main__":
     api_url = os.environ.get('GITHUB_API_URL') or github.MainClass.DEFAULT_BASE_URL
 
     check_name = get_var('CHECK_NAME') or 'Unit Test Results'
-    annotations = get_var('CHECK_RUN_ANNOTATIONS') or 'skipped tests, all tests'
-    annotations = [annotation.strip()
-                   for annotation in annotations.split(',')]
+    annotations = get_annotations_config(event)
+
     settings = Settings(
         token=get_var('GITHUB_TOKEN'),
         api_url=api_url,

--- a/publish_unit_test_results.py
+++ b/publish_unit_test_results.py
@@ -72,11 +72,11 @@ def get_annotations_config(event: Optional[dict]) -> List[str]:
         if annotations else default_annotations
     default_branch = event.get('repository', {}).get('default_branch') if event else None
     annotations_branch = get_var('CHECK_RUN_ANNOTATIONS_BRANCH') or default_branch or 'main, master'
-    annotations_branches = {branch.strip() for branch in annotations_branch.split(',')}
+    annotations_branches = {f'refs/heads/{branch.strip()}' for branch in annotations_branch.split(',')}
     branch = get_var('GITHUB_REF')
 
     if annotations and branch and annotations_branches and \
-            '*' not in annotations_branches and \
+            'refs/heads/*' not in annotations_branches and \
             branch not in annotations_branches:
         branches = "', '".join(annotations_branches)
         logger.info(f"Current branch '{branch}' not among branches '{branches}', "

--- a/test/test_publisher.py
+++ b/test/test_publisher.py
@@ -37,7 +37,7 @@ class TestPublisher(unittest.TestCase):
                         hide_comment_mode=hide_comments_mode_off,
                         report_individual_runs=False,
                         dedup_classes_by_file_name=False,
-                        check_run_annotation=available_annotations,
+                        check_run_annotation=default_annotations,
                         before: Optional[str] = 'before'):
         return Settings(
             token=None,
@@ -445,7 +445,10 @@ class TestPublisher(unittest.TestCase):
         )
 
     def test_publish_check_without_annotations(self):
-        self.do_test_publish_check_without_base_stats([], [])
+        self.do_test_publish_check_without_base_stats([], [none_list])
+
+    def test_publish_check_with_default_annotations(self):
+        self.do_test_publish_check_without_base_stats([], default_annotations)
 
     def test_publish_check_with_all_tests_annotations(self):
         self.do_test_publish_check_without_base_stats([], [all_tests_list])
@@ -459,7 +462,7 @@ class TestPublisher(unittest.TestCase):
     def test_publish_check_without_base_stats_with_errors(self):
         self.do_test_publish_check_without_base_stats(errors)
 
-    def do_test_publish_check_without_base_stats(self, errors: List[ParseError], annotations: List[str] = available_annotations):
+    def do_test_publish_check_without_base_stats(self, errors: List[ParseError], annotations: List[str] = default_annotations):
         settings = self.create_settings(before=None, check_run_annotation=annotations)
         gh, gha, req, repo, commit = self.create_mocks(commit=mock.Mock(), digest=None, check_names=[])
         publisher = Publisher(settings, gh, gha)


### PR DESCRIPTION
The test list annotations (all tests, skipped tests) are only published on default branch. This is configurable.