### PR TITLE
Moves test list in comments into details section

### DIFF
--- a/publish/__init__.py
+++ b/publish/__init__.py
@@ -398,10 +398,12 @@ def get_test_changes_summary_md(changes: Optional[SomeTestChanges], list_limit: 
     if changes.removed_skips() and changes.added_and_skipped():
         test_changes_details.append(
             get_test_changes_md(
-                'This pull request <b>removes</b> {} skipped tests and <b>adds</b> {} skipped tests. '
+                'This pull request <b>removes</b> {} skipped test{} and <b>adds</b> {} skipped test{}. '
                 '<i>Note that renamed tests count towards both.</i>'.format(
                     len(changes.removed_skips()),
-                    len(changes.added_and_skipped())
+                    's' if len(changes.removed_skips()) > 1 else '',
+                    len(changes.added_and_skipped()),
+                    's' if len(changes.added_and_skipped()) > 1 else ''
                 ),
                 list_limit,
                 changes.removed_skips(),

--- a/publish/__init__.py
+++ b/publish/__init__.py
@@ -4,7 +4,7 @@ import json
 import logging
 import re
 from collections import defaultdict
-from typing import List, Any, Union, Optional, Tuple, Mapping, Iterator, Set
+from typing import List, Any, Union, Optional, Tuple, Mapping, Iterator, Set, Iterable
 
 from dataclasses import dataclass
 
@@ -364,19 +364,6 @@ def get_short_summary_md(stats: UnitTestRunResultsOrDeltaResults) -> str:
     return md
 
 
-def get_test_list_summary_md(label: str, tests: Set[str], list_limit: Optional[int]) -> str:
-    if not tests:
-        return ''
-    if list_limit is None:
-        list_limit = len(tests)
-
-    amount = len(tests)
-    quantity = 'All' if amount <= list_limit else f'The first {list_limit}'
-    return '\n'.join(
-        [f'**{quantity} {label} tests are:**', '```'] + sorted(tests)[:list_limit] + ['```']
-    )
-
-
 def get_test_changes_summary_md(changes: Optional[SomeTestChanges], list_limit: Optional[int]) -> str:
     if not changes:
         return ''
@@ -385,59 +372,87 @@ def get_test_changes_summary_md(changes: Optional[SomeTestChanges], list_limit: 
     if changes.removes():
         if changes.adds():
             test_changes_details.append(
-                'This pull request **removes** {} and **adds** {} tests. '
-                '*Note that renamed tests count towards both.*'.format(
-                    len(changes.removes()),
-                    len(changes.adds()),
+                get_test_changes_md(
+                    'This pull request <b>removes</b> {} and <b>adds</b> {} tests. '
+                    '<i>Note that renamed tests count towards both.</i>'.format(
+                        len(changes.removes()),
+                        len(changes.adds()),
+                    ),
+                    list_limit,
+                    changes.removes(),
+                    changes.adds()
                 )
             )
         else:
             test_changes_details.append(
-                'This pull request **removes** {} test{}.'.format(
-                    len(changes.removes()),
-                    's' if len(changes.removes()) > 1 else ''
+                get_test_changes_md(
+                    'This pull request <b>removes</b> {} test{}.'.format(
+                        len(changes.removes()),
+                        's' if len(changes.removes()) > 1 else ''
+                    ),
+                    list_limit,
+                    list(changes.removes())
                 )
             )
-        test_changes_details.append('')
-        test_changes_details.append(get_test_list_summary_md('removed', changes.removes(), list_limit))
 
     if changes.remaining_and_skipped():
-        if test_changes_details:
-            test_changes_details.append('')
-
         if changes.remaining_and_un_skipped():
             test_changes_details.append(
-                'This pull request **skips** {} and **un-skips** {} tests.'.format(
-                    len(changes.remaining_and_skipped()),
-                    len(changes.remaining_and_un_skipped())
+                get_test_changes_md(
+                    'This pull request <b>skips</b> {} and <b>un-skips</b> {} tests.'.format(
+                        len(changes.remaining_and_skipped()),
+                        len(changes.remaining_and_un_skipped())
+                    ),
+                    list_limit,
+                    changes.remaining_and_skipped(),
+                    changes.remaining_and_un_skipped()
                 )
             )
         else:
             test_changes_details.append(
-                'This pull request **skips** {} test{}.'.format(
-                    len(changes.remaining_and_skipped()),
-                    's' if len(changes.remaining_and_skipped()) > 1 else ''
+                get_test_changes_md(
+                    'This pull request <b>skips</b> {} test{}.'.format(
+                        len(changes.remaining_and_skipped()),
+                        's' if len(changes.remaining_and_skipped()) > 1 else ''
+                    ),
+                    list_limit,
+                    changes.remaining_and_skipped()
                 )
             )
-        test_changes_details.append('')
-        test_changes_details.append(
-            get_test_list_summary_md('newly skipped', changes.remaining_and_skipped(), list_limit)
-        )
 
     if changes.removed_skips() and changes.added_and_skipped():
-        test_changes_details.append('')
         test_changes_details.append(
-            'This pull request **removes** {} skipped tests and **adds** {} skipped tests. '
-            '*Note that renamed tests count towards both.*'.format(
-                len(changes.removed_skips()),
-                len(changes.added_and_skipped())
+            get_test_changes_md(
+                'This pull request <b>removes</b> {} skipped tests and <b>adds</b> {} skipped tests. '
+                '<i>Note that renamed tests count towards both.</i>'.format(
+                    len(changes.removed_skips()),
+                    len(changes.added_and_skipped())
+                ),
+                list_limit,
+                changes.removed_skips(),
+                changes.added_and_skipped()
             )
         )
 
-    if test_changes_details:
-        test_changes_details.append('')
-
     return '\n'.join(test_changes_details)
+
+
+def get_test_changes_md(summary: str, list_limit: int, *tests: Iterable[str]) -> str:
+    tests = '\n'.join([get_test_changes_list_md(sorted(test), list_limit) for test in tests])
+    return (
+        f'<details>\n'
+        f'  <summary>{summary}</summary>\n'
+        f'\n'
+        f'{tests}'
+        f'</details>\n'
+    )
+
+
+def get_test_changes_list_md(tests: List[str], limit: int) -> str:
+    if limit:
+        tests = tests[:limit] + (['…'] if len(tests) > limit else [])
+    tests = '\n'.join(tests)
+    return f'```\n{tests}\n```\n'
 
 
 def get_long_summary_md(stats: UnitTestRunResultsOrDeltaResults,

--- a/publish/__init__.py
+++ b/publish/__init__.py
@@ -395,6 +395,20 @@ def get_test_changes_summary_md(changes: Optional[SomeTestChanges], list_limit: 
                 )
             )
 
+    if changes.removed_skips() and changes.added_and_skipped():
+        test_changes_details.append(
+            get_test_changes_md(
+                'This pull request <b>removes</b> {} skipped tests and <b>adds</b> {} skipped tests. '
+                '<i>Note that renamed tests count towards both.</i>'.format(
+                    len(changes.removed_skips()),
+                    len(changes.added_and_skipped())
+                ),
+                list_limit,
+                changes.removed_skips(),
+                changes.added_and_skipped()
+            )
+        )
+
     if changes.remaining_and_skipped():
         if changes.remaining_and_un_skipped():
             test_changes_details.append(
@@ -419,20 +433,6 @@ def get_test_changes_summary_md(changes: Optional[SomeTestChanges], list_limit: 
                     changes.remaining_and_skipped()
                 )
             )
-
-    if changes.removed_skips() and changes.added_and_skipped():
-        test_changes_details.append(
-            get_test_changes_md(
-                'This pull request <b>removes</b> {} skipped tests and <b>adds</b> {} skipped tests. '
-                '<i>Note that renamed tests count towards both.</i>'.format(
-                    len(changes.removed_skips()),
-                    len(changes.added_and_skipped())
-                ),
-                list_limit,
-                changes.removed_skips(),
-                changes.added_and_skipped()
-            )
-        )
 
     return '\n'.join(test_changes_details)
 

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -668,7 +668,7 @@ class PublishTest(unittest.TestCase):
             '</details>\n'
             '\n'
             '<details>\n'
-            '  <summary>This pull request <b>removes</b> 1 skipped tests and <b>adds</b> 1 skipped tests. '
+            '  <summary>This pull request <b>removes</b> 1 skipped test and <b>adds</b> 1 skipped test. '
             '<i>Note that renamed tests count towards both.</i></summary>\n'
             '\n'
             '```\n'
@@ -699,8 +699,8 @@ class PublishTest(unittest.TestCase):
             ),
             'https://details.url/',
             SomeTestChanges(
-                ['test1', 'test2', 'test3', 'test4', 'test5'], ['test5', 'test6'],
-                ['test2'], ['test5', 'test6']
+                ['test1', 'test2', 'test3', 'test4', 'test5'], ['test5', 'test6', 'test7'],
+                ['test1', 'test2'], ['test5', 'test6', 'test7']
             ),
             3
         ), ('1 files  2 suites   3s :stopwatch:\n'
@@ -709,7 +709,7 @@ class PublishTest(unittest.TestCase):
             'Results for commit commit.\n'
             '\n'
             '<details>\n'
-            '  <summary>This pull request <b>removes</b> 4 and <b>adds</b> 1 tests. '
+            '  <summary>This pull request <b>removes</b> 4 and <b>adds</b> 2 tests. '
             '<i>Note that renamed tests count towards both.</i></summary>\n'
             '\n'
             '```\n'
@@ -721,19 +721,22 @@ class PublishTest(unittest.TestCase):
             '\n'
             '```\n'
             'test6\n'
+            'test7\n'
             '```\n'
             '</details>\n'
             '\n'
             '<details>\n'
-            '  <summary>This pull request <b>removes</b> 1 skipped tests and <b>adds</b> 1 skipped tests. '
+            '  <summary>This pull request <b>removes</b> 2 skipped tests and <b>adds</b> 2 skipped tests. '
             '<i>Note that renamed tests count towards both.</i></summary>\n'
             '\n'
             '```\n'
+            'test1\n'
             'test2\n'
             '```\n'
             '\n'
             '```\n'
             'test6\n'
+            'test7\n'
             '```\n'
             '</details>\n'
             '\n'
@@ -1072,7 +1075,7 @@ class PublishTest(unittest.TestCase):
         expected = expected + (
             '\n'
             '<details>\n'
-            '  <summary>This pull request <b>removes</b> 1 skipped tests and <b>adds</b> 1 skipped tests. '
+            '  <summary>This pull request <b>removes</b> 1 skipped test and <b>adds</b> 1 skipped test. '
             '<i>Note that renamed tests count towards both.</i></summary>\n'
             '\n'
             '```\n'

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -668,14 +668,6 @@ class PublishTest(unittest.TestCase):
             '</details>\n'
             '\n'
             '<details>\n'
-            '  <summary>This pull request <b>skips</b> 1 test.</summary>\n'
-            '\n'
-            '```\n'
-            'test5\n'
-            '```\n'
-            '</details>\n'
-            '\n'
-            '<details>\n'
             '  <summary>This pull request <b>removes</b> 1 skipped tests and <b>adds</b> 1 skipped tests. '
             '<i>Note that renamed tests count towards both.</i></summary>\n'
             '\n'
@@ -685,6 +677,14 @@ class PublishTest(unittest.TestCase):
             '\n'
             '```\n'
             'test6\n'
+            '```\n'
+            '</details>\n'
+            '\n'
+            '<details>\n'
+            '  <summary>This pull request <b>skips</b> 1 test.</summary>\n'
+            '\n'
+            '```\n'
+            'test5\n'
             '```\n'
             '</details>\n')
         )
@@ -725,14 +725,6 @@ class PublishTest(unittest.TestCase):
             '</details>\n'
             '\n'
             '<details>\n'
-            '  <summary>This pull request <b>skips</b> 1 test.</summary>\n'
-            '\n'
-            '```\n'
-            'test5\n'
-            '```\n'
-            '</details>\n'
-            '\n'
-            '<details>\n'
             '  <summary>This pull request <b>removes</b> 1 skipped tests and <b>adds</b> 1 skipped tests. '
             '<i>Note that renamed tests count towards both.</i></summary>\n'
             '\n'
@@ -742,6 +734,14 @@ class PublishTest(unittest.TestCase):
             '\n'
             '```\n'
             'test6\n'
+            '```\n'
+            '</details>\n'
+            '\n'
+            '<details>\n'
+            '  <summary>This pull request <b>skips</b> 1 test.</summary>\n'
+            '\n'
+            '```\n'
+            'test5\n'
             '```\n'
             '</details>\n')
         )
@@ -1059,6 +1059,33 @@ class PublishTest(unittest.TestCase):
         expected = expected.replace('test1', 'test1\n```\n\n```\ntest2')
         self.assertEqual(expected, get_test_changes_summary_md(changes, 3))
 
+        changes.removed_skips = mock.Mock(return_value=[])
+        self.assertEqual(expected, get_test_changes_summary_md(changes, 3))
+
+        changes.added_and_skipped = mock.Mock(return_value=[])
+        self.assertEqual(expected, get_test_changes_summary_md(changes, 3))
+
+        changes.removed_skips = mock.Mock(return_value=['test5'])
+        self.assertEqual(expected, get_test_changes_summary_md(changes, 3))
+
+        changes.added_and_skipped = mock.Mock(return_value=['test6'])
+        expected = expected + (
+            '\n'
+            '<details>\n'
+            '  <summary>This pull request <b>removes</b> 1 skipped tests and <b>adds</b> 1 skipped tests. '
+            '<i>Note that renamed tests count towards both.</i></summary>\n'
+            '\n'
+            '```\n'
+            'test5\n'
+            '```\n'
+            '\n'
+            '```\n'
+            'test6\n'
+            '```\n'
+            '</details>\n'
+        )
+        self.assertEqual(expected, get_test_changes_summary_md(changes, 3))
+
         changes.remaining_and_skipped = mock.Mock(return_value=[])
         self.assertEqual(expected, get_test_changes_summary_md(changes, 3))
 
@@ -1081,33 +1108,6 @@ class PublishTest(unittest.TestCase):
         changes.remaining_and_un_skipped = mock.Mock(return_value=['test4'])
         expected = expected.replace('This pull request <b>skips</b> 1 test.', 'This pull request <b>skips</b> 1 and <b>un-skips</b> 1 tests.')
         expected = expected.replace('test3', 'test3\n```\n\n```\ntest4')
-        self.assertEqual(expected, get_test_changes_summary_md(changes, 3))
-
-        changes.removed_skips = mock.Mock(return_value=[])
-        self.assertEqual(expected, get_test_changes_summary_md(changes, 3))
-
-        changes.added_and_skipped = mock.Mock(return_value=[])
-        self.assertEqual(expected, get_test_changes_summary_md(changes, 3))
-
-        changes.removed_skips = mock.Mock(return_value=['test5'])
-        self.assertEqual(expected, get_test_changes_summary_md(changes, 3))
-
-        changes.added_and_skipped = mock.Mock(return_value=['test6'])
-        expected = expected + (
-                       '\n'
-                       '<details>\n'
-                       '  <summary>This pull request <b>removes</b> 1 skipped tests and <b>adds</b> 1 skipped tests. '
-                       '<i>Note that renamed tests count towards both.</i></summary>\n'
-                       '\n'
-                       '```\n'
-                       'test5\n'
-                       '```\n'
-                       '\n'
-                       '```\n'
-                       'test6\n'
-                       '```\n'
-                       '</details>\n'
-                   )
         self.assertEqual(expected, get_test_changes_summary_md(changes, 3))
 
     def test_get_test_changes_summary_md_add_tests(self):

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -651,10 +651,10 @@ class PublishTest(unittest.TestCase):
             '\n'
             'Results for commit commit.\n'
             '\n'
-            'This pull request **removes** 4 and **adds** 1 tests. '
-            '*Note that renamed tests count towards both.*\n'
+            '<details>\n'
+            '  <summary>This pull request <b>removes</b> 4 and <b>adds</b> 1 tests. '
+            '<i>Note that renamed tests count towards both.</i></summary>\n'
             '\n'
-            '**All removed tests are:**\n'
             '```\n'
             'test1\n'
             'test2\n'
@@ -662,15 +662,31 @@ class PublishTest(unittest.TestCase):
             'test4\n'
             '```\n'
             '\n'
-            'This pull request **skips** 1 test.\n'
+            '```\n'
+            'test6\n'
+            '```\n'
+            '</details>\n'
             '\n'
-            '**All newly skipped tests are:**\n'
+            '<details>\n'
+            '  <summary>This pull request <b>skips</b> 1 test.</summary>\n'
+            '\n'
             '```\n'
             'test5\n'
             '```\n'
+            '</details>\n'
             '\n'
-            'This pull request **removes** 1 skipped tests and **adds** 1 skipped tests. '
-            '*Note that renamed tests count towards both.*\n')
+            '<details>\n'
+            '  <summary>This pull request <b>removes</b> 1 skipped tests and <b>adds</b> 1 skipped tests. '
+            '<i>Note that renamed tests count towards both.</i></summary>\n'
+            '\n'
+            '```\n'
+            'test2\n'
+            '```\n'
+            '\n'
+            '```\n'
+            'test6\n'
+            '```\n'
+            '</details>\n')
         )
 
     def test_get_long_summary_md_with_test_lists_and_limit(self):
@@ -692,25 +708,42 @@ class PublishTest(unittest.TestCase):
             '\n'
             'Results for commit commit.\n'
             '\n'
-            'This pull request **removes** 4 and **adds** 1 tests. '
-            '*Note that renamed tests count towards both.*\n'
+            '<details>\n'
+            '  <summary>This pull request <b>removes</b> 4 and <b>adds</b> 1 tests. '
+            '<i>Note that renamed tests count towards both.</i></summary>\n'
             '\n'
-            '**The first 3 removed tests are:**\n'
             '```\n'
             'test1\n'
             'test2\n'
             'test3\n'
+            '…\n'
             '```\n'
             '\n'
-            'This pull request **skips** 1 test.\n'
+            '```\n'
+            'test6\n'
+            '```\n'
+            '</details>\n'
             '\n'
-            '**All newly skipped tests are:**\n'
+            '<details>\n'
+            '  <summary>This pull request <b>skips</b> 1 test.</summary>\n'
+            '\n'
             '```\n'
             'test5\n'
             '```\n'
+            '</details>\n'
             '\n'
-            'This pull request **removes** 1 skipped tests and **adds** 1 skipped tests. '
-            '*Note that renamed tests count towards both.*\n')
+            '<details>\n'
+            '  <summary>This pull request <b>removes</b> 1 skipped tests and <b>adds</b> 1 skipped tests. '
+            '<i>Note that renamed tests count towards both.</i></summary>\n'
+            '\n'
+            '```\n'
+            'test2\n'
+            '```\n'
+            '\n'
+            '```\n'
+            'test6\n'
+            '```\n'
+            '</details>\n')
         )
 
     def test_get_long_summary_md_with_all_tests_removed(self):
@@ -914,30 +947,81 @@ class PublishTest(unittest.TestCase):
             ))
         self.assertIn('stats must be UnitTestRunResults when no digest_stats is given', context.exception.args)
 
-    def test_get_test_list_summary_md(self):
-        self.assertEqual('', get_test_list_summary_md('label', set(), 3))
-        self.assertEqual('**All label tests are:**\n```\ntest1\n```', get_test_list_summary_md('label', {'test1'}, 3))
-        self.assertEqual('**All label tests are:**\n```\ntest1\ntest2\n```', get_test_list_summary_md('label', {'test1', 'test2'}, 3))
-        self.assertEqual('**All label tests are:**\n```\ntest1\ntest2\ntest3\n```', get_test_list_summary_md('label', {'test1', 'test2', 'test3'}, 3))
-        self.assertEqual('**The first 3 label tests are:**\n```\ntest1\ntest2\ntest3\n```', get_test_list_summary_md('label', {'test1', 'test2', 'test3', 'test4'}, 3))
+    def test_get_test_changes_md(self):
+        self.assertEqual(
+            '<details>\n'
+            '  <summary>the summary</summary>\n'
+            '\n'
+            '```\n'
+            'test1\n'
+            'test2\n'
+            '```\n'
+            '</details>\n',
+            get_test_changes_md('the summary', 3, ['test1', 'test2'])
+        )
+        self.assertEqual(
+            '<details>\n'
+            '  <summary>the summary</summary>\n'
+            '\n'
+            '```\n'
+            'test1\n'
+            'test2\n'
+            '```\n'
+            '\n'
+            '```\n'
+            'test3\n'
+            'test4\n'
+            'test5\n'
+            '…\n'
+            '```\n'
+            '</details>\n',
+            get_test_changes_md('the summary', 3, ['test1', 'test2'], ['test3', 'test4', 'test5', 'test6'])
+        )
+
+    def test_get_test_changes_list_md(self):
+        self.assertEqual('```\n\n```\n', get_test_changes_list_md([], 3))
+        self.assertEqual('```\ntest1\n```\n', get_test_changes_list_md(['test1'], 3))
+        self.assertEqual('```\ntest1\ntest2\n```\n', get_test_changes_list_md(['test1', 'test2'], 3))
+        self.assertEqual('```\ntest1\ntest2\ntest3\n```\n', get_test_changes_list_md(['test1', 'test2', 'test3'], 3))
+        self.assertEqual('```\ntest1\ntest2\ntest3\n…\n```\n', get_test_changes_list_md(['test1', 'test2', 'test3', 'test4'], 3))
 
     def test_get_test_changes_summary_md(self):
         changes = SomeTestChanges(
             ['test', 'test1', 'test2', 'test3'], ['test', 'test 1', 'test 2', 'test 3'],
             ['test1', 'test2'], ['test 1', 'test 2', 'test 3']
         )
-        self.assertEqual('This pull request **removes** 3 and **adds** 3 tests. '
-                         '*Note that renamed tests count towards both.*\n'
+        self.assertEqual('<details>\n'
+                         '  <summary>This pull request <b>removes</b> 3 and <b>adds</b> 3 tests. '
+                         '<i>Note that renamed tests count towards both.</i></summary>\n'
                          '\n'
-                         '**All removed tests are:**\n'
                          '```\n'
                          'test1\n'
                          'test2\n'
                          'test3\n'
                          '```\n'
                          '\n'
-                         'This pull request **removes** 2 skipped tests and **adds** 3 skipped tests. '
-                         '*Note that renamed tests count towards both.*\n',
+                         '```\n'
+                         'test 1\n'
+                         'test 2\n'
+                         'test 3\n'
+                         '```\n'
+                         '</details>\n'
+                         '\n'
+                         '<details>\n'
+                         '  <summary>This pull request <b>removes</b> 2 skipped tests and <b>adds</b> 3 skipped tests. '
+                         '<i>Note that renamed tests count towards both.</i></summary>\n'
+                         '\n'
+                         '```\n'
+                         'test1\n'
+                         'test2\n'
+                         '```\n'
+                         '\n'
+                         '```\n'
+                         'test 1\n'
+                         'test 2\n'
+                         'test 3\n'
+                         '```\n'
+                         '</details>\n',
                          get_test_changes_summary_md(changes, 3))
 
     def test_get_test_changes_summary_md_with_nones(self):
@@ -955,39 +1039,48 @@ class PublishTest(unittest.TestCase):
         self.assertEqual(expected, get_test_changes_summary_md(changes, 3))
 
         changes.removes = mock.Mock(return_value=['test1'])
-        expected = ('This pull request **removes** 1 test.\n'
-                    '\n'
-                    '**All removed tests are:**\n'
-                    '```\n'
-                    'test1\n'
-                    '```\n')
+        expected = (
+            '<details>\n'
+            '  <summary>This pull request <b>removes</b> 1 test.</summary>\n'
+            '\n'
+            '```\n'
+            'test1\n'
+            '```\n'
+            '</details>\n'
+        )
         self.assertEqual(expected, get_test_changes_summary_md(changes, 3))
 
         changes.adds = mock.Mock(return_value=[])
         self.assertEqual(expected, get_test_changes_summary_md(changes, 3))
 
         changes.adds = mock.Mock(return_value=['test2'])
-        expected = expected.replace('1 test.', '1 and **adds** 1 tests. *Note that renamed tests count towards both.*')
+        expected = expected.replace('1 test.', '1 and <b>adds</b> 1 tests. '
+                                               '<i>Note that renamed tests count towards both.</i>')
+        expected = expected.replace('test1', 'test1\n```\n\n```\ntest2')
         self.assertEqual(expected, get_test_changes_summary_md(changes, 3))
 
         changes.remaining_and_skipped = mock.Mock(return_value=[])
         self.assertEqual(expected, get_test_changes_summary_md(changes, 3))
 
         changes.remaining_and_skipped = mock.Mock(return_value=['test3'])
-        expected = expected + '\n' \
-                              'This pull request **skips** 1 test.\n' \
-                              '\n' \
-                              '**All newly skipped tests are:**\n' \
-                              '```\n' \
-                              'test3\n' \
-                              '```\n'
+        expected = expected + (
+            '\n'
+            '<details>\n'
+            '  <summary>This pull request <b>skips</b> 1 test.</summary>\n'
+            '\n'
+            '```\n'
+            'test3\n'
+            '```\n'
+            '</details>\n'
+        )
         self.assertEqual(expected, get_test_changes_summary_md(changes, 3))
 
         changes.remaining_and_un_skipped = mock.Mock(return_value=[])
         self.assertEqual(expected, get_test_changes_summary_md(changes, 3))
 
         changes.remaining_and_un_skipped = mock.Mock(return_value=['test4'])
-        expected = expected.replace('This pull request **skips** 1 test.', 'This pull request **skips** 1 and **un-skips** 1 tests.')
+        expected = expected.replace('This pull request <b>skips</b> 1 test.', 'This pull request <b>skips</b> 1 and <b>un-skips</b> 1 tests.')
+        expected = expected.replace('test3', 'test3\n```\n\n```\ntest4')
         self.assertEqual(expected, get_test_changes_summary_md(changes, 3))
 
         changes.removed_skips = mock.Mock(return_value=[])
@@ -1000,9 +1093,21 @@ class PublishTest(unittest.TestCase):
         self.assertEqual(expected, get_test_changes_summary_md(changes, 3))
 
         changes.added_and_skipped = mock.Mock(return_value=['test6'])
-        expected = expected + '\n' \
-                              'This pull request **removes** 1 skipped tests and **adds** 1 skipped tests. ' \
-                              '*Note that renamed tests count towards both.*\n'
+        expected = expected + (
+                       '\n'
+                       '<details>\n'
+                       '  <summary>This pull request <b>removes</b> 1 skipped tests and <b>adds</b> 1 skipped tests. '
+                       '<i>Note that renamed tests count towards both.</i></summary>\n'
+                       '\n'
+                       '```\n'
+                       'test5\n'
+                       '```\n'
+                       '\n'
+                       '```\n'
+                       'test6\n'
+                       '```\n'
+                       '</details>\n'
+                   )
         self.assertEqual(expected, get_test_changes_summary_md(changes, 3))
 
     def test_get_test_changes_summary_md_add_tests(self):
@@ -1017,12 +1122,13 @@ class PublishTest(unittest.TestCase):
             ['test1', 'test2', 'test3'], ['test1', 'test3'],
             [], []
         )
-        self.assertEqual('This pull request **removes** 1 test.\n'
+        self.assertEqual('<details>\n'
+                         '  <summary>This pull request <b>removes</b> 1 test.</summary>\n'
                          '\n'
-                         '**All removed tests are:**\n'
                          '```\n'
                          'test2\n'
-                         '```\n',
+                         '```\n'
+                         '</details>\n',
                          get_test_changes_summary_md(changes, 3))
 
     def test_get_test_changes_summary_md_remove_tests(self):
@@ -1030,13 +1136,14 @@ class PublishTest(unittest.TestCase):
             ['test1', 'test2', 'test3'], ['test1'],
             [], []
         )
-        self.assertEqual('This pull request **removes** 2 tests.\n'
+        self.assertEqual('<details>\n'
+                         '  <summary>This pull request <b>removes</b> 2 tests.</summary>\n'
                          '\n'
-                         '**All removed tests are:**\n'
                          '```\n'
                          'test2\n'
                          'test3\n'
-                         '```\n',
+                         '```\n'
+                         '</details>\n',
                          get_test_changes_summary_md(changes, 3))
 
     def test_get_test_changes_summary_md_rename_tests(self):
@@ -1044,15 +1151,22 @@ class PublishTest(unittest.TestCase):
             ['test1', 'test2', 'test3'], ['test 1', 'test 2', 'test 3'],
             [], []
         )
-        self.assertEqual('This pull request **removes** 3 and **adds** 3 tests. '
-                         '*Note that renamed tests count towards both.*\n'
+        self.assertEqual('<details>\n'
+                         '  <summary>This pull request <b>removes</b> 3 and <b>adds</b> 3 tests. '
+                         '<i>Note that renamed tests count towards both.</i></summary>\n'
                          '\n'
-                         '**All removed tests are:**\n'
                          '```\n'
                          'test1\n'
                          'test2\n'
                          'test3\n'
-                         '```\n',
+                         '```\n'
+                         '\n'
+                         '```\n'
+                         'test 1\n'
+                         'test 2\n'
+                         'test 3\n'
+                         '```\n'
+                         '</details>\n',
                          get_test_changes_summary_md(changes, 3))
 
     def test_get_test_changes_summary_md_skip_test(self):
@@ -1060,12 +1174,13 @@ class PublishTest(unittest.TestCase):
             ['test1', 'test2', 'test3'], ['test1', 'test2', 'test3'],
             [], ['test1']
         )
-        self.assertEqual('This pull request **skips** 1 test.\n'
+        self.assertEqual('<details>\n'
+                         '  <summary>This pull request <b>skips</b> 1 test.</summary>\n'
                          '\n'
-                         '**All newly skipped tests are:**\n'
                          '```\n'
                          'test1\n'
-                         '```\n',
+                         '```\n'
+                         '</details>\n',
                          get_test_changes_summary_md(changes, 3))
 
     def test_get_test_changes_summary_md_skip_tests(self):
@@ -1073,13 +1188,14 @@ class PublishTest(unittest.TestCase):
             ['test1', 'test2', 'test3'], ['test1', 'test2', 'test3'],
             [], ['test1', 'test3']
         )
-        self.assertEqual('This pull request **skips** 2 tests.\n'
+        self.assertEqual('<details>\n'
+                         '  <summary>This pull request <b>skips</b> 2 tests.</summary>\n'
                          '\n'
-                         '**All newly skipped tests are:**\n'
                          '```\n'
                          'test1\n'
                          'test3\n'
-                         '```\n',
+                         '```\n'
+                         '</details>\n',
                          get_test_changes_summary_md(changes, 3))
 
     def test_get_test_changes_summary_md_un_skip_tests(self):
@@ -1094,12 +1210,17 @@ class PublishTest(unittest.TestCase):
             ['test1', 'test2', 'test3'], ['test1', 'test2', 'test3'],
             ['test1', 'test2'], ['test1', 'test3']
         )
-        self.assertEqual('This pull request **skips** 1 and **un-skips** 1 tests.\n'
+        self.assertEqual('<details>\n'
+                         '  <summary>This pull request <b>skips</b> 1 and <b>un-skips</b> 1 tests.</summary>\n'
                          '\n'
-                         '**All newly skipped tests are:**\n'
                          '```\n'
                          'test3\n'
-                         '```\n',
+                         '```\n'
+                         '\n'
+                         '```\n'
+                         'test2\n'
+                         '```\n'
+                         '</details>\n',
                          get_test_changes_summary_md(changes, 3))
 
     def test_get_test_changes_summary_md_rename_skip_tests(self):
@@ -1107,18 +1228,37 @@ class PublishTest(unittest.TestCase):
             ['test1', 'test2', 'test3'], ['test 1', 'test 2', 'test 3'],
             ['test1', 'test2'], ['test 1', 'test 2']
         )
-        self.assertEqual('This pull request **removes** 3 and **adds** 3 tests. '
-                         '*Note that renamed tests count towards both.*\n'
+        self.assertEqual('<details>\n'
+                         '  <summary>This pull request <b>removes</b> 3 and <b>adds</b> 3 tests. '
+                         '<i>Note that renamed tests count towards both.</i></summary>\n'
                          '\n'
-                         '**All removed tests are:**\n'
                          '```\n'
                          'test1\n'
                          'test2\n'
                          'test3\n'
                          '```\n'
                          '\n'
-                         'This pull request **removes** 2 skipped tests and **adds** 2 skipped tests. '
-                         '*Note that renamed tests count towards both.*\n',
+                         '```\n'
+                         'test 1\n'
+                         'test 2\n'
+                         'test 3\n'
+                         '```\n'
+                         '</details>\n'
+                         '\n'
+                         '<details>\n'
+                         '  <summary>This pull request <b>removes</b> 2 skipped tests and <b>adds</b> 2 skipped tests. '
+                         '<i>Note that renamed tests count towards both.</i></summary>\n'
+                         '\n'
+                         '```\n'
+                         'test1\n'
+                         'test2\n'
+                         '```\n'
+                         '\n'
+                         '```\n'
+                         'test 1\n'
+                         'test 2\n'
+                         '```\n'
+                         '</details>\n',
                          get_test_changes_summary_md(changes, 3))
 
     def test_get_case_messages(self):


### PR DESCRIPTION
Uses colapsable `<details>` sections for list of changed tests. Fixes #83.