### PR TITLE
Isolate action on pull_request_target

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,16 +1,11 @@
 name: CI/CD
 
-on: [push, pull_request_target]
+on: [push]
 
 jobs:
   build-and-test:
     name: Build and Test
     runs-on: ubuntu-latest
-    # always run on push events, but only run on pull_request_target event when pull request pulls from fork repository
-    # for pull requests within the same repository, the pull event is sufficient
-    if: >
-      github.event_name == 'push' ||
-      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
 
     steps:
     - name: Setup Ubuntu
@@ -68,7 +63,6 @@ jobs:
 
     # only deploy pushed version tags (no major versions), but not on forked repositories
     if: >
-      github.event_name == 'push' &&
       startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '.') &&
       github.repository_owner == 'EnricoMi'
 

--- a/.github/workflows/fork.yml
+++ b/.github/workflows/fork.yml
@@ -1,0 +1,17 @@
+name: Fork
+
+on: [pull_request_target]
+
+jobs:
+  comment:
+    name: Unit Test Results from Fork
+    runs-on: ubuntu-latest
+    # Only run if pull request is coming from a fork
+    if: github.event.pull_request.head.repo.full_name != github.repository
+
+    steps:
+      - name: Post Pull Request Comment
+        uses: EnricoMi/publish-unit-test-result-action@branch-pull-request-target
+        with:
+          check_name: Unit Test Results
+          log_level: DEBUG

--- a/README.md
+++ b/README.md
@@ -131,10 +131,15 @@ This feature requires `check_run_annotations` to contain `all tests` in order to
 and removal, and `skipped tests` to detect new skipped and un-skipped tests, as well as
 `check_run_annotations_branch` to contain your default branch.
 
+Test results of a pull request from a fork cannot be published to your repository directly, so
+a second action run has to pull the results into your repository. This action looks for the results
+every `pull_from_fork_intervall_seconds` (default is 30).
+It gives up after `pull_from_fork_timeout_minutes` (default is 30).
+
 See this complete list of configuration options for reference:
 ```yaml
   with:
-    github_token: ${{ your-custom-pat }}
+    github_token: ${{ secrets.PAT }}
     commit: ${{ your-commit-sha }}
     check_name: Unit Test Results
     comment_title: Unit Test Statistics
@@ -146,6 +151,8 @@ See this complete list of configuration options for reference:
     deduplicate_classes_by_file_name: false
     check_run_annotations_branch: main, master, branch_one
     check_run_annotations: all tests, skipped tests
+    pull_from_fork_timeout_minutes: 30
+    pull_from_fork_intervall_seconds: 30
 ```
 
 ## On GitHub Events
@@ -195,7 +202,7 @@ If you are using the default value, then this option can be omitted.
 Please [read and accept the risk](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target)
 running this action in your repo's context when using `pull_request_target`.
 
-### Why are fork reposiories so complicated?
+### Why are fork repositories so complicated?
 
 This action posts a comment with test results to all pull requests that contain the commit and
 are part of the repository that the action runs in. It would not be able to post to pull requests

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,14 @@ inputs:
     description: 'Adds check run annotations only on given branches. If not given, this defaults to all branches. Comma separated list of branch names allowed, asterisk "*" matches all branches.'
     required: false
     default: '*'
+  pull_from_fork_timeout_minutes:
+    description: 'Pulling the test results from a fork waits at most this number of minutes for the results to appear.'
+    required: false
+    default: '30'
+  pull_from_fork_intervall_seconds:
+    description: 'Pulling the test results from a fork checks for the results at an interval of this number of seconds.'
+    required: false
+    default: '30'
   log_level:
     description: 'Action logging level'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -42,8 +42,9 @@ inputs:
     required: false
     default: 'all tests, skipped tests'
   check_run_annotations_branch:
-    description: 'Adds check run annotations only on given branches. If not given, this defaults to the default branch of your repository, e.g. main or master. Comma separated list of branch names allowed, asterisk "*" matches all branches.'
+    description: 'Adds check run annotations only on given branches. If not given, this defaults to all branches. Comma separated list of branch names allowed, asterisk "*" matches all branches.'
     required: false
+    default: '*'
   log_level:
     description: 'Action logging level'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -17,8 +17,9 @@ inputs:
     description: 'Title of PR comments, defaults to value of check_name input'
     required: false
   files:
-    description: 'File pattern of test result files'
+    description: 'File pattern of test result files. Required unless action runs on pull_request_target event.'
     required: true
+    default: ''
   report_individual_runs:
     description: 'Individual runs of the same test may see different failures. Reports all individual failures when set "true" or the first only otherwise'
     required: false

--- a/publish/publisher.py
+++ b/publish/publisher.py
@@ -127,6 +127,8 @@ class Publisher:
 
         runs = commit.get_check_runs()
         logger.debug(f'found {runs.totalCount} check runs for commit {commit_sha}')
+        for run in runs:
+            logger.debug(f'found check run {run.name}')
         runs = list([run for run in runs if run.name == self._settings.check_name])
         logger.debug(f'found {len(runs)} check runs for commit {commit_sha} with title {self._settings.check_name}')
         if len(runs) != 1:
@@ -265,7 +267,7 @@ class Publisher:
             check_run = self.get_check_run(commit_sha)
             if check_run is not None:
                 break
-            if datetime.utcnow() - start > timedelta(minutes=5):
+            if datetime.utcnow() - start > timedelta(minutes=15):
                 logger.debug(f'could not find a check run for commit {commit_sha}')
                 return
             time.sleep(30)

--- a/publish/publisher.py
+++ b/publish/publisher.py
@@ -32,6 +32,8 @@ class Settings:
     report_individual_runs: bool
     dedup_classes_by_file_name: bool
     check_run_annotation: List[str]
+    pull_from_fork_timeout: timedelta
+    pull_from_fork_interval: timedelta
 
 
 class Publisher:
@@ -271,9 +273,9 @@ class Publisher:
             check_run_head = self.get_check_run(commit_sha, pull_request.head.repo)
             if check_run_base is not None or check_run_head is not None:
                 break
-            if datetime.utcnow() - start > timedelta(minutes=15):
+            if datetime.utcnow() - start > self._settings.pull_from_fork_timeout:
                 raise RuntimeError(f'could not find a check run for commit {commit_sha}')
-            time.sleep(30)
+            time.sleep(self._settings.pull_from_fork_interval.total_seconds())
 
         check_run = check_run_base or check_run_head
         stats = self.get_stats_from_check_run(check_run)

--- a/publish/publisher.py
+++ b/publish/publisher.py
@@ -5,6 +5,7 @@ from github import Github
 from github.CheckRun import CheckRun
 from github.CheckRunAnnotation import CheckRunAnnotation
 from github.PullRequest import PullRequest
+from github.Repository import Repository
 
 from github_action import GithubAction
 from publish import *
@@ -116,11 +117,14 @@ class Publisher:
         check_run = self.get_check_run(commit_sha)
         return self.get_stats_from_check_run(check_run) if check_run is not None else None
 
-    def get_check_run(self, commit_sha: str) -> Optional[CheckRun]:
+    def get_check_run(self, commit_sha: str, repo: Optional[Repository] = None) -> Optional[CheckRun]:
+        if repo is None:
+            repo = self._repo
+
         if commit_sha is None or commit_sha == '0000000000000000000000000000000000000000':
             return None
 
-        commit = self._repo.get_commit(commit_sha)
+        commit = repo.get_commit(commit_sha)
         if commit is None:
             self._gha.error(f'Could not find commit {commit_sha}')
             return None
@@ -264,7 +268,7 @@ class Publisher:
         # get check run and stats for commit
         start = datetime.utcnow()
         while True:
-            check_run = self.get_check_run(commit_sha)
+            check_run = self.get_check_run(commit_sha, pull_request.head.repo)
             if check_run is not None:
                 break
             if datetime.utcnow() - start > timedelta(minutes=15):

--- a/publish/publisher.py
+++ b/publish/publisher.py
@@ -267,13 +267,15 @@ class Publisher:
         # get check run and stats for commit
         start = datetime.utcnow()
         while True:
-            check_run = self.get_check_run(commit_sha, pull_request.head.repo)
-            if check_run is not None:
+            check_run_base = self.get_check_run(commit_sha, pull_request.base.repo)
+            check_run_head = self.get_check_run(commit_sha, pull_request.head.repo)
+            if check_run_base is not None or check_run_head is not None:
                 break
             if datetime.utcnow() - start > timedelta(minutes=15):
                 raise RuntimeError(f'could not find a check run for commit {commit_sha}')
             time.sleep(30)
 
+        check_run = check_run_base or check_run_head
         stats = self.get_stats_from_check_run(check_run)
         if stats is None:
             raise RuntimeError(f'could not find stats in check run for commit {commit_sha}')

--- a/publish/publisher.py
+++ b/publish/publisher.py
@@ -272,14 +272,12 @@ class Publisher:
             if check_run is not None:
                 break
             if datetime.utcnow() - start > timedelta(minutes=15):
-                logger.debug(f'could not find a check run for commit {commit_sha}')
-                return
+                raise RuntimeError(f'could not find a check run for commit {commit_sha}')
             time.sleep(30)
 
         stats = self.get_stats_from_check_run(check_run)
         if stats is None:
-            logger.debug(f'could not find stats in check run for commit {commit_sha}')
-            return
+            raise RuntimeError(f'could not find stats in check run for commit {commit_sha}')
 
         # compare them with earlier stats
         base_commit_sha = pull_request.base.sha if pull_request else None

--- a/publish_unit_test_results.py
+++ b/publish_unit_test_results.py
@@ -3,6 +3,7 @@ import logging
 import os
 import pathlib
 import sys
+from datetime import timedelta
 from typing import List, Optional, Union
 
 import github
@@ -142,6 +143,13 @@ def get_settings(options: dict) -> Settings:
     check_name = get_var('CHECK_NAME', options) or 'Unit Test Results'
     annotations = get_annotations_config(options, event)
 
+    pull_from_fork_timeout_minutes = get_var('PULL_FROM_FORK_TIMEOUT_MINUTES', options)
+    pull_from_fork_timeout_minutes = int(pull_from_fork_timeout_minutes) \
+        if pull_from_fork_timeout_minutes and pull_from_fork_timeout_minutes.isdigit() else 30
+    pull_from_fork_interval_seconds = get_var('PULL_FROM_FORK_INTERVAL_SECONDS', options)
+    pull_from_fork_interval_seconds = int(pull_from_fork_interval_seconds) \
+        if pull_from_fork_interval_seconds and pull_from_fork_interval_seconds.isdigit() else 30
+
     settings = Settings(
         token=get_var('GITHUB_TOKEN', options),
         api_url=api_url,
@@ -157,7 +165,9 @@ def get_settings(options: dict) -> Settings:
         hide_comment_mode=get_var('HIDE_COMMENTS', options) or 'all but latest',
         report_individual_runs=get_var('REPORT_INDIVIDUAL_RUNS', options) == 'true',
         dedup_classes_by_file_name=get_var('DEDUPLICATE_CLASSES_BY_FILE_NAME', options) == 'true',
-        check_run_annotation=annotations
+        check_run_annotation=annotations,
+        pull_from_fork_timeout=timedelta(minutes=pull_from_fork_timeout_minutes),
+        pull_from_fork_interval=timedelta(seconds=pull_from_fork_interval_seconds)
     )
 
     check_var(settings.token, 'GITHUB_TOKEN', 'GitHub token')

--- a/publish_unit_test_results.py
+++ b/publish_unit_test_results.py
@@ -29,7 +29,9 @@ def get_conclusion(parsed: ParsedUnitTestResults) -> str:
 
 
 def main(settings: Settings) -> None:
+    gh = github.Github(login_or_token=settings.token, base_url=settings.api_url)
     gha = GithubAction()
+    publisher = Publisher(settings, gh, gha)
 
     if settings.files_glob:
         # resolve the files_glob to files
@@ -55,12 +57,10 @@ def main(settings: Settings) -> None:
         conclusion = get_conclusion(parsed)
 
         # publish the delta stats
-        gh = github.Github(login_or_token=settings.token, base_url=settings.api_url)
-        Publisher(settings, gh, gha).publish(stats, results.case_results, conclusion)
+        publisher.publish(stats, results.case_results, conclusion)
     elif settings.event_name == 'pull_request_target':
         # publish pull request comment from existing check run
-        gh = github.Github(login_or_token=settings.token, base_url=settings.api_url)
-        Publisher(settings, gh, gha).publish_pull_request_target()
+        publisher.publish_from_check_run()
     else:
         raise ValueError(f'Files option must be given when not running on pull_request_target event: {settings.event_name}.')
 

--- a/publish_unit_test_results.py
+++ b/publish_unit_test_results.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import pathlib
+import sys
 from typing import List, Optional, Union
 
 import github
@@ -175,4 +176,10 @@ if __name__ == "__main__":
     publisher.logger.level = logging.getLevelName(log_level)
 
     settings = get_settings(options)
-    main(settings)
+
+    try:
+        main(settings)
+    except Exception as e:
+        gha = GithubAction()
+        gha.error(str(e))
+        sys.exit(1)

--- a/publish_unit_test_results.py
+++ b/publish_unit_test_results.py
@@ -69,7 +69,8 @@ def main(settings: Settings) -> None:
         publisher.publish(stats, results.case_results, conclusion)
     elif settings.event_name == 'pull_request_target':
         # publish pull request comment from existing check run
-        publisher.publish_from_check_run()
+        repo_name = settings.event.get('pull_request', {}).get('head', {}).get('repo', {}).get('full_name', settings.repo)
+        publisher.publish_from_check_run(repo_name)
     else:
         raise ValueError(f'Files option must be given when not running on pull_request_target event: {settings.event_name}.')
 

--- a/publish_unit_test_results.py
+++ b/publish_unit_test_results.py
@@ -33,6 +33,14 @@ def main(settings: Settings) -> None:
     gha = GithubAction()
     publisher = Publisher(settings, gh, gha)
 
+    # we cannot create a check run or pull request comment
+    # when running on pull_request event from a fork
+    if settings.event_name == 'pull_request' and \
+            settings.event.get('pull_request', {}).get('head', {}).get('repo', {}).get('full_name') != settings.repo:
+        gha.warning(f'This action is running on a pull_request event for a fork repository. '
+                    f'It cannot do anything useful like creating check runs or pull request comments.')
+        return
+
     if settings.files_glob:
         # resolve the files_glob to files
         files = [str(file) for file in pathlib.Path().glob(settings.files_glob)]

--- a/test/test_action_script.py
+++ b/test/test_action_script.py
@@ -2,6 +2,7 @@ import json
 import os
 import tempfile
 import unittest
+from datetime import timedelta
 from typing import Optional
 
 import mock
@@ -115,7 +116,9 @@ class Test(unittest.TestCase):
                      hide_comment_mode='off',
                      report_individual_runs=True,
                      dedup_classes_by_file_name=True,
-                     check_run_annotation=[]):
+                     check_run_annotation=[],
+                     pull_from_fork_timeout=timedelta(minutes=1),
+                     pull_from_fork_interval=timedelta(minutes=1)):
         return Settings(
             token=token,
             api_url=api_url,
@@ -131,7 +134,9 @@ class Test(unittest.TestCase):
             hide_comment_mode=hide_comment_mode,
             report_individual_runs=report_individual_runs,
             dedup_classes_by_file_name=dedup_classes_by_file_name,
-            check_run_annotation=check_run_annotation.copy()
+            check_run_annotation=check_run_annotation.copy(),
+            pull_from_fork_timeout=pull_from_fork_timeout,
+            pull_from_fork_interval=pull_from_fork_interval
         )
 
     def test_get_settings(self):
@@ -195,6 +200,10 @@ class Test(unittest.TestCase):
         self.do_test_get_settings(DEDUPLICATE_CLASSES_BY_FILE_NAME='foo', expected=self.get_settings(dedup_classes_by_file_name=False))
         self.do_test_get_settings(DEDUPLICATE_CLASSES_BY_FILE_NAME=None, expected=self.get_settings(dedup_classes_by_file_name=False))
 
+    def test_get_settings_pull_from_fork_defaults(self):
+        self.do_test_get_settings(PULL_FROM_FORK_TIMEOUT_MINUTES=None, expected=self.get_settings(pull_from_fork_timeout=timedelta(minutes=30)))
+        self.do_test_get_settings(PULL_FROM_FORK_INTERVAL_SECONDS=None, expected=self.get_settings(pull_from_fork_interval=timedelta(seconds=30)))
+
     def test_get_settings_missing_options(self):
         with self.assertRaises(RuntimeError) as re:
             self.do_test_get_settings(GITHUB_EVENT_PATH=None)
@@ -252,6 +261,8 @@ class Test(unittest.TestCase):
                 HIDE_COMMENTS='off',  # defaults to 'all but latest'
                 REPORT_INDIVIDUAL_RUNS='true',  # false unless 'true'
                 DEDUPLICATE_CLASSES_BY_FILE_NAME='true',  # false unless 'true'
+                PULL_FROM_FORK_TIMEOUT_MINUTES='1',
+                PULL_FROM_FORK_INTERVAL_SECONDS='60'
                 # annotations config tested in test_get_annotations_config*
             )
             options.update(**kwargs)

--- a/test/test_action_script.py
+++ b/test/test_action_script.py
@@ -1,8 +1,10 @@
+import json
 import os
 import tempfile
 import unittest
+from typing import Optional
+
 import mock
-import json
 
 from publish_unit_test_results import get_conclusion, get_commit_sha, \
     get_settings, get_annotations_config, Settings
@@ -105,7 +107,7 @@ class Test(unittest.TestCase):
                      event_name='event name',
                      repo='repo',
                      commit='commit',
-                     files_glob='files',
+                     files_glob: Optional[str] = 'files',
                      check_name='check name',
                      comment_title='title',
                      comment_on_pr=True,
@@ -213,6 +215,8 @@ class Test(unittest.TestCase):
         with self.assertRaises(RuntimeError) as re:
             self.do_test_get_settings(FILES=None)
         self.assertEqual('Files pattern must be provided via action input or environment variable FILES', str(re.exception))
+        # files is not required when event_name is 'pull_request_target'
+        self.do_test_get_settings(FILES=None, expected=self.get_settings(files_glob=None, event_name='pull_request_target'), GITHUB_EVENT_NAME='pull_request_target')
 
     def test_get_settings_unknown_values(self):
         with self.assertRaises(RuntimeError) as re:

--- a/test/test_action_script.py
+++ b/test/test_action_script.py
@@ -102,6 +102,7 @@ class Test(unittest.TestCase):
     def get_settings(token='token',
                      api_url='http://github.api.url/',
                      event={},
+                     event_name='event name',
                      repo='repo',
                      commit='commit',
                      files_glob='files',
@@ -117,6 +118,7 @@ class Test(unittest.TestCase):
             token=token,
             api_url=api_url,
             event=event.copy(),
+            event_name=event_name,
             repo=repo,
             commit=commit,
             files_glob=files_glob,
@@ -142,11 +144,11 @@ class Test(unittest.TestCase):
 
     def test_get_settings_commit_default(self):
         event = {'pull_request': {'head': {'sha': 'sha2'}}}
-        self.do_test_get_settings(INPUT_COMMIT='sha', GITHUB_EVENT_NAME='pull_request', event=event, GITHUB_SHA='default', expected=self.get_settings(commit='sha', event=event))
-        self.do_test_get_settings(COMMIT='sha', GITHUB_EVENT_NAME='pull_request', event=event, GITHUB_SHA='default', expected=self.get_settings(commit='sha', event=event))
-        self.do_test_get_settings(COMMIT=None, GITHUB_EVENT_NAME='pull_request', event=event, GITHUB_SHA='default', expected=self.get_settings(commit='sha2', event=event))
-        self.do_test_get_settings(COMMIT=None, INPUT_GITHUB_EVENT_NAME='pull_request', event=event, GITHUB_SHA='default', expected=self.get_settings(commit='sha2', event=event))
-        self.do_test_get_settings(COMMIT=None, GITHUB_EVENT_NAME='push', event=event, GITHUB_SHA='default', expected=self.get_settings(commit='default', event=event))
+        self.do_test_get_settings(INPUT_COMMIT='sha', GITHUB_EVENT_NAME='pull_request', event=event, GITHUB_SHA='default', expected=self.get_settings(commit='sha', event=event, event_name='pull_request'))
+        self.do_test_get_settings(COMMIT='sha', GITHUB_EVENT_NAME='pull_request', event=event, GITHUB_SHA='default', expected=self.get_settings(commit='sha', event=event, event_name='pull_request'))
+        self.do_test_get_settings(COMMIT=None, GITHUB_EVENT_NAME='pull_request', event=event, GITHUB_SHA='default', expected=self.get_settings(commit='sha2', event=event, event_name='pull_request'))
+        self.do_test_get_settings(COMMIT=None, INPUT_GITHUB_EVENT_NAME='pull_request', event=event, GITHUB_SHA='default', expected=self.get_settings(commit='sha2', event=event, event_name='pull_request'))
+        self.do_test_get_settings(COMMIT=None, GITHUB_EVENT_NAME='push', event=event, GITHUB_SHA='default', expected=self.get_settings(commit='default', event=event, event_name='push'))
         with self.assertRaises(RuntimeError, msg='Commit SHA must be provided via action input or environment variable COMMIT, GITHUB_SHA or event file'):
             self.do_test_get_settings(COMMIT=None, GITHUB_EVENT_NAME='pull_request', event={}, GITHUB_SHA='default', expected=None)
         with self.assertRaises(RuntimeError, msg='Commit SHA must be provided via action input or environment variable COMMIT, GITHUB_SHA or event file'):

--- a/test/test_publisher.py
+++ b/test/test_publisher.py
@@ -1,6 +1,6 @@
 import unittest
 from collections.abc import Collection
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Callable, Optional, Mapping, List, Tuple, Any, Union
 
 import mock
@@ -60,7 +60,9 @@ class TestPublisher(unittest.TestCase):
             hide_comment_mode=hide_comment_mode,
             report_individual_runs=report_individual_runs,
             dedup_classes_by_file_name=dedup_classes_by_file_name,
-            check_run_annotation=check_run_annotation
+            check_run_annotation=check_run_annotation,
+            pull_from_fork_timeout=timedelta(minutes=1),
+            pull_from_fork_interval=timedelta(minutes=1)
         )
 
     stats = UnitTestRunResults(


### PR DESCRIPTION
The action now can run on a `pull_request_target` event without the `files` options. Then, it copies the test result earlier published in the fork repository. This allows to not run the entire unit test workflow on `pull_request_target`, but ordinary `push` or `pull_request` events-

Running the CI pipeline on `pull_request_target` events might be risky as it runs arbitrary code from a fork in your repository context. It is better to run the action on `pull_request` or`push` events, which publishes unit tests results to the fork repository only.

Then we have to run the action again on a `pull_request_target` event, which will copy the results over into a pull request comment in the target repository. This time, only the action runs in the target repo context.

Note: running the action on either `pull_request` or `push` events in your repository will be able to post comments to the pull request in your repository.