### PR TITLE
Use the built-in venv module and enable venv caching

### DIFF
--- a/composite/action.yml
+++ b/composite/action.yml
@@ -59,9 +59,11 @@ runs:
   using: 'composite'
   steps:
     - name: Check for Python3
+      id: python-check
       run: |
         echo '##[group]Check for Python3'
-        if ! which python3
+        interpreter=python3
+        if ! which $interpreter
         then
           if ! which python || [[ $(python -V) != *"python 3."* ]]
           then
@@ -71,20 +73,25 @@ runs:
 
           interpreter="$(which python)"
           interpreter3="${interpreter}3"
-          if [[ ! -e "$interpreter3" ]]
+          if [[ -e "$interpreter3" ]]
           then
-            ln -s $interpreter3 $interpreter
+            interpreter="$interpreter3"
           fi
+        else
+          interpreter="$(which python3)"
         fi
+        if command -v realpath &> /dev/null
+        then
+          interpreter="$(realpath $interpreter)"
+        fi
+        echo "::set-output name=interpreter::$interpreter"
         echo '##[endgroup]'
       shell: bash
 
     - name: Install Python dependencies
       run: |
         echo '##[group]Install Python dependencies'
-        # venv module fails if run through a symlink,
-        # see https://github.com/actions/virtual-environments/issues/2690
-        PY=$(realpath $(which python3))
+        PY="${{ steps.python-check.outputs.interpreter }}"
         "$PY" -m venv venv
         [ -f venv/bin/activate ] && source venv/bin/activate || source venv/Scripts/activate
         python -m pip install --upgrade --no-cache-dir wheel

--- a/composite/action.yml
+++ b/composite/action.yml
@@ -82,11 +82,13 @@ runs:
     - name: Install Python dependencies
       run: |
         echo '##[group]Install Python dependencies'
-        python3 -m pip install --upgrade --force --no-cache-dir pip
-        python3 -m pip install --upgrade --force --no-cache-dir virtualenv
-        python3 -m virtualenv -p python3 venv
-        [ -f venv/bin/activate ] && source venv/bin/activate || source venv/Scripts/Activate
-        python3 -m pip install --upgrade --force --no-cache-dir -r $GITHUB_ACTION_PATH/../python/requirements.txt
+        # venv module fails if run through a symlink,
+        # see https://github.com/actions/virtual-environments/issues/2690
+        PY=$(realpath $(which python3))
+        "$PY" -m venv venv
+        [ -f venv/bin/activate ] && source venv/bin/activate || source venv/Scripts/activate
+        python -m pip install --upgrade --no-cache-dir wheel
+        python -m pip install --upgrade --no-cache-dir -r $GITHUB_ACTION_PATH/../python/requirements.txt
         echo '##[endgroup]'
       shell: bash
 
@@ -94,7 +96,7 @@ runs:
       run: |
         echo '##[group]Publish Unit Test Results'
         [ -f venv/bin/activate ] && source venv/bin/activate || source venv/Scripts/Activate
-        python3 $GITHUB_ACTION_PATH/../python/publish_unit_test_results.py
+        python $GITHUB_ACTION_PATH/../python/publish_unit_test_results.py
         echo '##[endgroup]'
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}


### PR DESCRIPTION
Creation of the venv in the composite version of the module takes quite  long time. This change enables caching of the `venv/` directory by the calling workflow. Unfortunately, the composite action cannot perform the caching itself because `uses:` is not supported for composite actions. The `README.md` now explains how this can be done, however.