### PR TITLE
Remove venv and pip upgrade from composite action

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -177,20 +177,37 @@ jobs:
 
       - name: Detect OS
         id: os
-        run: |
-          case "$OS" in
-            macos*) echo "::set-output name=path-sep::/";;
-            ubuntu*) echo "::set-output name=path-sep::/";;
-            windows*) echo "::set-output name=path-sep::\\";;
-          esac
-        shell: bash
         env:
           OS: ${{ matrix.os }}
+        run: |
+          case "$OS" in
+            ubuntu*)
+              echo "::set-output name=path-sep::/"
+              echo "::set-output name=pip-cache::~/.cache/pip"
+              ;;
+            macos*)
+              echo "::set-output name=path-sep::/"
+              echo "::set-output name=pip-cache::~/Library/Caches/pip"
+              ;;
+            windows*)
+              echo "::set-output name=path-sep::\\"
+              echo "::set-output name=pip-cache::~\\AppData\\Local\\pip\\Cache"
+              ;;
+          esac
+        shell: bash
 
       - name: Download Artifacts
         uses: actions/download-artifact@v2
         with:
           path: artifacts
+
+      - name: Cache PIP Packages
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.os.outputs.pip-cache }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
 
       - name: Publish Unit Test Results
         uses: ./composite
@@ -211,6 +228,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Cache PIP Packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-extra-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-extra-
+            ${{ runner.os }}-pip-
 
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -203,11 +203,16 @@ jobs:
 
       - name: Cache PIP Packages
         uses: actions/cache@v2
+        id: cache
         with:
           path: ${{ steps.os.outputs.pip-cache }}
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', 'composite/action.yml') }}
           restore-keys: |
             ${{ runner.os }}-pip-
+
+      - name: Install package wheel
+        if: steps.cache.outputs.cache-hit != 'true' && runner.os == 'Windows'
+        run: python3 -m pip install wheel
 
       - name: Publish Unit Test Results
         uses: ./composite

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -205,7 +205,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.os.outputs.pip-cache }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('composite/action.yml') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', 'composite/action.yml') }}
           restore-keys: |
             ${{ runner.os }}-pip-
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -205,7 +205,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.os.outputs.pip-cache }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('composite/action.yml') }}
           restore-keys: |
             ${{ runner.os }}-pip-
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -238,7 +238,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-extra-${{ hashFiles('**/requirements.txt') }}
+          key: ${{ runner.os }}-pip-extra-${{ hashFiles('**/requirements.txt', 'composite/action.yml') }}
           restore-keys: |
             ${{ runner.os }}-pip-extra-
             ${{ runner.os }}-pip-

--- a/README.md
+++ b/README.md
@@ -248,8 +248,27 @@ publish-test-results:
        files: artifacts/**/*.xml
 ```
 
-In situations where downloading the action's dependency packages takes very long,
-you can [cache files downloaded by PIP](https://github.com/actions/cache/blob/main/examples.md#python---pip).
+In situations where downloading the action's dependency packages and building wheel files takes very long,
+you can [cache files downloaded and built by PIP](https://github.com/actions/cache/blob/main/examples.md#python---pip).
+This is especially useful for Windows runner:
+
+```yaml
+- name: Cache PIP Packages
+  uses: actions/cache@v2
+  with:
+    path: ~\AppData\Local\pip\Cache
+    key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt, 'composite/action.yml') }}
+    restore-keys: |
+      ${{ runner.os }}-pip-
+- name: Publish Unit Test Results
+  uses: EnricoMi/publish-unit-test-result-action/composite@v1
+…
+```
+
+Use the correct `path:`, depending on your action runner's OS:
+- macOS: `~/Library/Caches/pip`
+- Windows: `~\AppData\Local\pip\Cache`
+- Ubuntu: `~/.cache/pip`
 
 ## Support fork repositories and dependabot branches
 

--- a/README.md
+++ b/README.md
@@ -248,28 +248,8 @@ publish-test-results:
        files: artifacts/**/*.xml
 ```
 
-In situations where downloading the action's dependency packages takes very long, you can [cache
-files downloaded by PIP](https://github.com/actions/cache/blob/main/examples.md#python---pip):
-
-```yaml
-- name: Cache PIP Packages
-  uses: actions/cache@v2
-  with:
-    path: ~/.cache/pip
-    key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-    restore-keys: |
-      ${{ runner.os }}-pip-
-
-- name: Publish Unit Test Results
-  uses: EnricoMi/publish-unit-test-result-action/composite@v1
-…
-```
-
-Use the correct `path:`, depending on your action runner's OS:
-
-- Ubuntu: `~/.cache/pip`
-- Windows: `~\AppData\Local\pip\Cache`
-- macOS: `~/Library/Caches/pip`
+In situations where downloading the action's dependency packages takes very long,
+you can [cache files downloaded by PIP](https://github.com/actions/cache/blob/main/examples.md#python---pip).
 
 ## Support fork repositories and dependabot branches
 

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ publish-test-results:
 
 In situations where downloading the action's dependency packages and building wheel files takes very long,
 you can [cache files downloaded and built by PIP](https://github.com/actions/cache/blob/main/examples.md#python---pip).
-This is especially useful for Windows runner:
+This is especially useful for *Windows* runners:
 
 ```yaml
 - name: Cache PIP Packages
@@ -260,6 +260,12 @@ This is especially useful for Windows runner:
     key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt, 'composite/action.yml') }}
     restore-keys: |
       ${{ runner.os }}-pip-
+
+- name: Install package wheel
+  # only needed on Windows, and only when on cache miss
+  if: steps.cache.outputs.cache-hit != 'true' && runner.os == 'Windows'
+  run: python3 -m pip install wheel
+
 - name: Publish Unit Test Results
   uses: EnricoMi/publish-unit-test-result-action/composite@v1
 …

--- a/README.md
+++ b/README.md
@@ -207,11 +207,12 @@ Self-hosted runners may require setting up a Python environment first:
 
 ### Isolating composite action from your workflow
 
-Note that the composite action modifies this Python environment by upgrading PIP and installing dependency packages.
-If this conflicts with actions that later run Python in the same workflow (rare case), it is recommended to run this action in an isolated workflow.
-This is similar to the workflows shown in [Use with matrix strategy](#use-with-matrix-strategy).
+Note that the composite action modifies this Python environment by installing dependency packages.
+If this conflicts with actions that later run Python in the same workflow (which is a rare case),
+it is recommended to run this action as the last step in your workflow, or to run it in an isolated workflow.
+Running it in an isolated workflow is similar to the workflows shown in [Use with matrix strategy](#use-with-matrix-strategy).
 
-Your CI workflow should upload all test result XML files:
+To run the composite action in an isolated workflow, your CI workflow should upload all test result XML files:
 
 ```yaml
 build-and-test:
@@ -234,7 +235,7 @@ Your dedicated publish-unit-test-result-workflow then downloads these files and 
 publish-test-results:
  name: "Publish Unit Tests Results"
  needs: build-and-test
- runs-on: macos-latest
+ runs-on: windows-latest
  # the build-and-test job might be skipped, we don't need to run this job then
  if: success() || failure()
 
@@ -252,7 +253,7 @@ publish-test-results:
 
 ### Slow startup of composite action
 
-In some environments, the composite action startup can be slow due to installing Python dependencies.
+In some environments, the composite action startup can be slow due to the installation of Python dependencies.
 This is usually the case for **Windows** runners (in this example 35 seconds startup time):
 
 ```
@@ -263,7 +264,7 @@ Mon, 03 May 2021 11:57:35 GMT   ⏵ Publish Unit Test Results
 ```
 
 This can be improved by caching the PIP cache directory. If you see the following warning in
-the composite action output, then installing the `wheel` package can also be beneficial (see further below):
+the composite action output, then installing the `wheel` package can also be beneficial (see further down):
 
 ```
 Using legacy 'setup.py install' for …, since package 'wheel' is not installed.
@@ -283,7 +284,7 @@ using the `actions/cache` action, and conditionally install the `wheel`package a
       ${{ runner.os }}-pip-
 
 # only needed if you see this warning in action log output otherwise:
-#   Using legacy 'setup.py install' for …, since package 'wheel' is not installed.
+# Using legacy 'setup.py install' for …, since package 'wheel' is not installed.
 - name: Install package wheel
   # only needed on cache miss
   if: steps.cache.outputs.cache-hit != 'true'

--- a/composite/action.yml
+++ b/composite/action.yml
@@ -85,18 +85,14 @@ runs:
     - name: Install Python dependencies
       run: |
         echo '##[group]Install Python dependencies'
-        python3 -m pip install --upgrade --force --no-cache-dir pip
-        python3 -m pip install --upgrade --force --no-cache-dir virtualenv
-        python3 -m virtualenv -p python3 venv
-        [ -f venv/bin/activate ] && source venv/bin/activate || source venv/Scripts/Activate
-        python3 -m pip install --upgrade --force --no-cache-dir -r $GITHUB_ACTION_PATH/../python/requirements.txt
+        python3 -m pip install --upgrade --force pip
+        python3 -m pip install --upgrade --force -r $GITHUB_ACTION_PATH/../python/requirements.txt
         echo '##[endgroup]'
       shell: bash
 
     - name: Publish Unit Test Results
       run: |
         echo '##[group]Publish Unit Test Results'
-        [ -f venv/bin/activate ] && source venv/bin/activate || source venv/Scripts/Activate
         python3 $GITHUB_ACTION_PATH/../python/publish_unit_test_results.py
         echo '##[endgroup]'
       env:

--- a/composite/action.yml
+++ b/composite/action.yml
@@ -85,8 +85,7 @@ runs:
     - name: Install Python dependencies
       run: |
         echo '##[group]Install Python dependencies'
-        python3 -m pip install --upgrade --force pip
-        python3 -m pip install --upgrade --force -r $GITHUB_ACTION_PATH/../python/requirements.txt
+        python3 -m pip install -r $GITHUB_ACTION_PATH/../python/requirements.txt
         echo '##[endgroup]'
       shell: bash
 

--- a/composite/action.yml
+++ b/composite/action.yml
@@ -85,12 +85,6 @@ runs:
     - name: Install Python dependencies
       run: |
         echo '##[group]Install Python dependencies'
-        if [ "${{ runner.os }}" == "Windows" ]
-        then
-          # windows needs wheel to build some dependencies
-          # where those wheel packages can then be cached
-          python3 -m pip install wheel
-        fi
         python3 -m pip install -r $GITHUB_ACTION_PATH/../python/requirements.txt
         echo '##[endgroup]'
       shell: bash

--- a/composite/action.yml
+++ b/composite/action.yml
@@ -85,6 +85,12 @@ runs:
     - name: Install Python dependencies
       run: |
         echo '##[group]Install Python dependencies'
+        if [ "${{ runner.os }}" == "Windows" ]
+        then
+          # windows needs wheel to build some dependencies
+          # where those wheel packages can then be cached
+          python3 -m pip install wheel
+        fi
         python3 -m pip install -r $GITHUB_ACTION_PATH/../python/requirements.txt
         echo '##[endgroup]'
       shell: bash

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
-# dataclasses does not exist in Python3.6, needed as dependency
-dataclasses
+# dataclasses does not exist before Python3.7, needed as dependency
+dataclasses;python_version<"3.7"
 junitparser==1.6.3
 PyGithub==1.54.1
 urllib3==1.26.4

--- a/python/test/test_action_script.py
+++ b/python/test/test_action_script.py
@@ -516,7 +516,6 @@ class Test(unittest.TestCase):
                                   ('*/*.txt', [os.path.join('sub1', 'file1.txt'), os.path.join('sub2', 'file2.txt')])]:
             with self.subTest(pattern=pattern):
                 with tempfile.TemporaryDirectory() as path:
-                    print(path)
                     filenames = [os.path.join('sub1', 'file1.txt'),
                                  os.path.join('sub2', 'file2.txt')]
                     with chdir(path):


### PR DESCRIPTION
To simplify the composite action and improve startup speed, lets remove using a virtual environment. This action can easily isolated from other actions that use the runner's Python environment by running it in a dedicated workflow. For the discussion, see #123.