### PR TITLE
Handle non-ASCII characters in event file

### DIFF
--- a/python/publish_unit_test_results.py
+++ b/python/publish_unit_test_results.py
@@ -157,7 +157,7 @@ def get_settings(options: dict, gha: Optional[GithubAction] = None) -> Settings:
     event_name = get_var('GITHUB_EVENT_NAME', options)
     check_var(event, 'GITHUB_EVENT_PATH', 'GitHub event file path')
     check_var(event_name, 'GITHUB_EVENT_NAME', 'GitHub event name')
-    with open(event, 'r') as f:
+    with open(event, 'rt', encoding='utf-8') as f:
         event = json.load(f)
     api_url = options.get('GITHUB_API_URL') or github.MainClass.DEFAULT_BASE_URL
     graphql_url = options.get('GITHUB_GRAPHQL_URL') or f'{github.MainClass.DEFAULT_BASE_URL}/graphql'

--- a/python/test/test_action_script.py
+++ b/python/test/test_action_script.py
@@ -305,7 +305,7 @@ class Test(unittest.TestCase):
         event = event.copy()
         with tempfile.TemporaryDirectory() as path:
             filepath = os.path.join(path, 'event.json')
-            with open(filepath, 'wt') as w:
+            with open(filepath, 'wt', encoding='utf-8') as w:
                 w.write(json.dumps(event))
 
             for key in ['GITHUB_EVENT_PATH', 'INPUT_GITHUB_EVENT_PATH']:

--- a/python/test/test_action_yml.py
+++ b/python/test/test_action_yml.py
@@ -7,10 +7,10 @@ from yaml import Loader
 class TestActionYml(unittest.TestCase):
 
     def test_composite_action(self):
-        with open('../../action.yml') as r:
+        with open('../../action.yml', encoding='utf-8') as r:
             dockerfile_action = yaml.load(r, Loader=Loader)
 
-        with open('../../composite/action.yml') as r:
+        with open('../../composite/action.yml', encoding='utf-8') as r:
             composite_action = yaml.load(r, Loader=Loader)
 
         self.assertIn('runs', dockerfile_action)
@@ -21,7 +21,7 @@ class TestActionYml(unittest.TestCase):
         self.assertIn(('using', 'composite'), composite_action.get('runs', {}).items())
 
     def test_composite_inputs(self):
-        with open('../../composite/action.yml') as r:
+        with open('../../composite/action.yml', encoding='utf-8') as r:
             action = yaml.load(r, Loader=Loader)
 
         # these are not documented in the action.yml files but still needs to be forwarded

--- a/python/test/test_cicd_yml.py
+++ b/python/test/test_cicd_yml.py
@@ -7,10 +7,10 @@ from yaml import Loader
 class TestActionYml(unittest.TestCase):
 
     def test_cicd_workflow(self):
-        with open('../../action.yml') as r:
+        with open('../../action.yml', encoding='utf-8') as r:
             action = yaml.load(r, Loader=Loader)
 
-        with open('../../.github/workflows/ci-cd.yml') as r:
+        with open('../../.github/workflows/ci-cd.yml', encoding='utf-8') as r:
             cicd = yaml.load(r, Loader=Loader)
 
         docker_image_steps = cicd.get('jobs', []).get('publish-docker-image', {}).get('steps', [])


### PR DESCRIPTION
The pull request title and body, as well as commit messages are part of the `event.json` file. That file is written with UTF8 encoding and read by the action. The action uses the system's default encoding when reading that JSON file, which is `cp1252` on Windows.

Fixes #129.