### PR TITLE
Handle multiple test list chunks

### DIFF
--- a/python/publish/__init__.py
+++ b/python/publish/__init__.py
@@ -721,10 +721,56 @@ def get_test_name(file_name: Optional[str],
 
 
 def get_all_tests_list(cases: UnitTestCaseResults) -> List[str]:
-    if cases is None:
-        return None
+    if not cases:
+        return []
     return [get_test_name(file_name, class_name, test_name)
             for (file_name, class_name, test_name) in cases.keys()]
+
+
+def get_skipped_tests_list(cases: UnitTestCaseResults) -> List[str]:
+    if not cases:
+        return []
+    return [get_test_name(file_name, class_name, test_name)
+            for (file_name, class_name, test_name), result in cases.items()
+            if 'skipped' in result and len(result) == 1]
+
+
+def get_all_tests_list_annotation(cases: UnitTestCaseResults, max_chunk_size: int = 64000) -> List[Annotation]:
+    return get_test_list_annotation(get_all_tests_list(cases), 'test', max_chunk_size)
+
+
+def get_skipped_tests_list_annotation(cases: UnitTestCaseResults, max_chunk_size: int = 64000) -> List[Annotation]:
+    return get_test_list_annotation(get_skipped_tests_list(cases), 'skipped test', max_chunk_size)
+
+
+def get_test_list_annotation(tests: List[str], label: str, max_chunk_size: int = 64000) -> List[Annotation]:
+    if len(tests) == 0:
+        return []
+
+    # the max_chunk_size must not be larger than the abbreviate_bytes limit in Annotation.to_dict
+    test_chunks = chunk_test_list(sorted(tests), '\n', max_chunk_size)
+
+    if len(test_chunks) == 1:
+        if len(tests) == 1:
+            title = f'{len(tests)} {label} found'
+            message = f'There is 1 {label}, see "Raw output" for the name of the {label}.'
+        else:
+            title = f'{len(tests)} {label}s found'
+            message = f'There are {len(tests)} {label}s, see "Raw output" for the full list of {label}s.'
+
+        return [create_tests_list_annotation(title=title, message=message, raw_details='\n'.join(test_chunks[0]))]
+
+    first = 1
+    annotations = []
+    for chunk in test_chunks:
+        last = first + len(chunk) - 1
+        title = f'{len(tests)} {label}s found (test {first} to {last})'
+        message = f'There are {len(tests)} {label}s, see "Raw output" for the list of {label}s {first} to {last}.'
+        annotation = create_tests_list_annotation(title=title, message=message, raw_details='\n'.join(chunk))
+        annotations.append(annotation)
+        first = last + 1
+
+    return annotations
 
 
 def chunk_test_list(tests: List[str], delimiter: str, max_chunk_size: int) -> List[List[str]]:
@@ -750,115 +796,15 @@ def chunk_test_list(tests: List[str], delimiter: str, max_chunk_size: int) -> Li
     return chunks
 
 
-def get_all_tests_list_annotation(cases: UnitTestCaseResults, max_chunk_size: int = 64000) -> List[Annotation]:
-    if not cases:
-        return []
-
-    test_list = get_all_tests_list(cases)
-    if len(test_list) == 1:
-        message = f'There is 1 test, see "Raw output" for the name of the test.'
-    else:
-        message = f'There are {len(test_list)} tests, see "Raw output" for the full list of tests.'
-
-    # the max_chunk_size must not be larger than the abbreviate_bytes limit in Annotation.to_dict
-    test_chunks = chunk_test_list(sorted(test_list), '\n', max_chunk_size)
-    if len(test_chunks) == 0:
-        return []
-
-    if len(test_chunks) == 1:
-        return [
-            Annotation(
-                path='.github',
-                start_line=0,
-                end_line=0,
-                start_column=None,
-                end_column=None,
-                annotation_level='notice',
-                message=message,
-                title=f'{len(cases)} test{"s" if len(cases) > 1 else ""} found',
-                raw_details='\n'.join(test_chunks[0])
-            )
-        ]
-
-    first = 1
-    annotations = []
-    for chunk in test_chunks:
-        last = first + len(chunk) - 1
-        message = f'There are {len(test_list)} tests, see "Raw output" for the list of tests {first} to {last}.'
-        annotation = Annotation(
-            path='.github',
-            start_line=0,
-            end_line=0,
-            start_column=None,
-            end_column=None,
-            annotation_level='notice',
-            message=message,
-            title=f'{len(cases)} test{"s" if len(cases) > 1 else ""} found (test {first} to {last})',
-            raw_details='\n'.join(chunk)
-        )
-        annotations.append(annotation)
-        first = last + 1
-
-    return annotations
-
-
-def get_skipped_tests_list(cases: UnitTestCaseResults) -> Optional[List[str]]:
-    if cases is None:
-        return None
-    tests = [key
-             for key, result in cases.items()
-             if 'skipped' in result and len(result) == 1]
-    return [get_test_name(file_name, class_name, test_name)
-            for (file_name, class_name, test_name) in tests]
-
-
-def get_skipped_tests_list_annotation(cases: UnitTestCaseResults, max_chunk_size: int = 64000) -> List[Annotation]:
-    skipped_tests = get_skipped_tests_list(cases)
-    if not skipped_tests:
-        return []
-
-    if len(skipped_tests) == 1:
-        message = f'There is 1 skipped test, see "Raw output" for the name of the skipped test.'
-    else:
-        message = f'There are {len(skipped_tests)} skipped tests, see "Raw output" for the full list of skipped tests.'
-
-    # the max_chunk_size must not be larger than the abbreviate_bytes limit in Annotation.to_dict
-    test_chunks = chunk_test_list(sorted(skipped_tests), '\n', max_chunk_size)
-    if len(test_chunks) == 0:
-        return []
-
-    if len(test_chunks) == 1:
-        return [
-            Annotation(
-                path='.github',
-                start_line=0,
-                end_line=0,
-                start_column=None,
-                end_column=None,
-                annotation_level='notice',
-                message=message,
-                title=f'{len(skipped_tests)} skipped test{"s" if len(skipped_tests) > 1 else ""} found',
-                raw_details='\n'.join(test_chunks[0])
-            )
-        ]
-
-    first = 1
-    annotations = []
-    for chunk in test_chunks:
-        last = first + len(chunk) - 1
-        message = f'There are {len(skipped_tests)} skipped tests, see "Raw output" for the list of skipped tests {first} to {last}.'
-        annotation = Annotation(
-            path='.github',
-            start_line=0,
-            end_line=0,
-            start_column=None,
-            end_column=None,
-            annotation_level='notice',
-            message=message,
-            title=f'{len(skipped_tests)} skipped test{"s" if len(skipped_tests) > 1 else ""} found (test {first} to {last})',
-            raw_details='\n'.join(chunk)
-        )
-        annotations.append(annotation)
-        first = last + 1
-
-    return annotations
+def create_tests_list_annotation(title: str, message: str, raw_details: Optional[str]) -> Annotation:
+    return Annotation(
+        path='.github',
+        start_line=0,
+        end_line=0,
+        start_column=None,
+        end_column=None,
+        annotation_level='notice',
+        message=message,
+        title=title,
+        raw_details=raw_details
+    )

--- a/python/publish/publisher.py
+++ b/python/publish/publisher.py
@@ -225,8 +225,7 @@ class Publisher:
 
     @staticmethod
     def get_test_list_from_annotations(annotations: List[CheckRunAnnotation],
-                                       title_regexp: re.Pattern,
-                                       message_regexp: re.Pattern) -> List[str]:
+                                       title_regexp, message_regexp) -> List[str]:
         test_annotations: List[CheckRunAnnotation] = []
 
         for annotation in annotations:

--- a/python/test/test_publish.py
+++ b/python/test/test_publish.py
@@ -1685,6 +1685,37 @@ class PublishTest(unittest.TestCase):
         del results[('file', 'class1', 'test2')]
         self.assertEqual([Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There is 1 test, see "Raw output" for the name of the test.', title='1 test found', raw_details='class1 ‑ test2')], get_all_tests_list_annotation(results))
 
+    def test_get_all_tests_list_annotation_chunked(self):
+        results = UnitTestCaseResults([
+            ((None, 'class1', 'test2'), dict([
+                ('success', list([
+                    UnitTestCase(result_file='result-file1', test_file='file1', line=123, class_name='class1', test_name='test2', result='success', message='success message', content='success content', time=1.0)
+                ])),
+            ])),
+            ((None, 'class1', 'test1'), dict([
+                ('success', list([
+                    UnitTestCase(result_file='result-file1', test_file='file1', line=123, class_name='class1', test_name='test1', result='success', message='success message', content='success content', time=1.0)
+                ])),
+                ('skipped', list([
+                    UnitTestCase(result_file='result-file1', test_file='file1', line=123, class_name=None, test_name='test1', result='skipped', message='skip message', content='skip content', time=None)
+                ])),
+            ])),
+            (('file', 'class1', 'test2'), dict([
+                ('success', list([
+                    UnitTestCase(result_file='result-file1', test_file='file1', line=123, class_name='class1', test_name='test2', result='success', message='success message', content='success content', time=1.0)
+                ])),
+            ]))
+        ])
+
+        self.assertEqual([], get_all_tests_list_annotation(UnitTestCaseResults()))
+        self.assertEqual(
+            [
+                Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There are 3 tests, see "Raw output" for the list of tests 1 to 2.', title='3 tests found (test 1 to 2)', raw_details='class1 ‑ test1\nclass1 ‑ test2'),
+                Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There are 3 tests, see "Raw output" for the list of tests 3 to 3.', title='3 tests found (test 3 to 3)', raw_details='file ‑ class1 ‑ test2')
+            ],
+            get_all_tests_list_annotation(results, max_chunk_size=40)
+        )
+
     def test_get_skipped_tests_list_annotation(self):
         results = UnitTestCaseResults([
             ((None, 'class1', 'test2'), dict([
@@ -1711,6 +1742,34 @@ class PublishTest(unittest.TestCase):
         self.assertEqual([Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There is 1 skipped test, see "Raw output" for the name of the skipped test.', title='1 skipped test found', raw_details='class1 ‑ test2')], get_skipped_tests_list_annotation(results))
         del results[(None, 'class1', 'test1')]['success']
         self.assertEqual([Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There are 2 skipped tests, see "Raw output" for the full list of skipped tests.', title='2 skipped tests found', raw_details='class1 ‑ test1\nclass1 ‑ test2')], get_skipped_tests_list_annotation(results))
+
+    def test_get_skipped_tests_list_annotation_chunked(self):
+        results = UnitTestCaseResults([
+            ((None, 'class1', 'test2'), dict([
+                ('skipped', list([
+                    UnitTestCase(result_file='result-file1', test_file='file1', line=123, class_name='class1', test_name='test2', result='success', message='success message', content='success content', time=1.0)
+                ])),
+            ])),
+            ((None, 'class1', 'test1'), dict([
+                ('skipped', list([
+                    UnitTestCase(result_file='result-file1', test_file='file1', line=123, class_name='class1', test_name='test1', result='success', message='success message', content='success content', time=1.0)
+                ])),
+            ])),
+            (('file', 'class1', 'test2'), dict([
+                ('skipped', list([
+                    UnitTestCase(result_file='result-file1', test_file='file1', line=123, class_name='class1', test_name='test2', result='success', message='success message', content='success content', time=1.0)
+                ])),
+            ]))
+        ])
+
+        self.assertEqual([], get_skipped_tests_list_annotation(UnitTestCaseResults()))
+        self.assertEqual(
+            [
+                Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There are 3 skipped tests, see "Raw output" for the list of skipped tests 1 to 2.', title='3 skipped tests found (test 1 to 2)', raw_details='class1 ‑ test1\nclass1 ‑ test2'),
+                Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There are 3 skipped tests, see "Raw output" for the list of skipped tests 3 to 3.', title='3 skipped tests found (test 3 to 3)', raw_details='file ‑ class1 ‑ test2')
+            ],
+            get_skipped_tests_list_annotation(results, max_chunk_size=40)
+        )
 
     def test_chunk(self):
         self.assertEqual([], chunk_test_list([], '\n', 100))

--- a/python/test/test_publisher.py
+++ b/python/test/test_publisher.py
@@ -639,6 +639,40 @@ class TestPublisher(unittest.TestCase):
             Publisher.get_test_lists_from_check_run(check_run)
         )
 
+    def test_get_test_lists_from_check_run_chunked_tests(self):
+        annotation1 = mock.Mock()
+        annotation1.title = None
+        annotation1.message = 'message one'
+        annotation1.raw_details = None
+
+        annotation2 = mock.Mock()
+        annotation2.title = '4 tests found (tests 1 to 2)'
+        annotation2.message = 'There are 4 tests, see "Raw output" for the list of tests 1 to 2.'
+        annotation2.raw_details = 'test one\ntest two'
+
+        annotation3 = mock.Mock()
+        annotation3.title = '4 tests found (tests 3 to 4)'
+        annotation3.message = 'There are 4 tests, see "Raw output" for the list of tests 3 to 4.'
+        annotation3.raw_details = 'test three\ntest four'
+
+        annotation4 = mock.Mock()
+        annotation4.title = '4 skipped tests found (tests 1 to 2)'
+        annotation4.message = 'There are 4 skipped tests, see "Raw output" for the list of skipped tests 1 to 2.'
+        annotation4.raw_details = 'skip one\nskip two'
+
+        annotation5 = mock.Mock()
+        annotation5.title = '4 skipped tests found (tests 3 to 4)'
+        annotation5.message = 'There are 4 skipped tests, see "Raw output" for the list of skipped tests 3 to 4.'
+        annotation5.raw_details = 'skip three\nskip four'
+
+        annotations = [annotation1, annotation2, annotation3, annotation4, annotation5]
+        check_run = mock.Mock()
+        check_run.get_annotations = mock.Mock(return_value=annotations)
+        self.assertEqual(
+            (['test one', 'test two', 'test three', 'test four'], ['skip one', 'skip two', 'skip three', 'skip four']),
+            Publisher.get_test_lists_from_check_run(check_run)
+        )
+
     def test_get_test_lists_from_check_run_none_raw_details(self):
         annotation1 = mock.Mock()
         annotation1.title = '1 test found'
@@ -653,16 +687,6 @@ class TestPublisher(unittest.TestCase):
         annotations = [annotation1, annotation2]
         check_run = mock.Mock()
         check_run.get_annotations = mock.Mock(return_value=annotations)
-        self.assertEqual((None, None), Publisher.get_test_lists_from_check_run(check_run))
-
-    def test_get_test_lists_from_check_run_multiple_all_tests(self):
-        check_run = mock.Mock()
-        check_run.get_annotations = mock.Mock(return_value=[self.all_tests_annotation, self.all_tests_annotation])
-        self.assertEqual((None, None), Publisher.get_test_lists_from_check_run(check_run))
-
-    def test_get_test_lists_from_check_run_multiple_skipped_tests(self):
-        check_run = mock.Mock()
-        check_run.get_annotations = mock.Mock(return_value=[self.skipped_tests_annotation, self.skipped_tests_annotation])
         self.assertEqual((None, None), Publisher.get_test_lists_from_check_run(check_run))
 
     def test_publish_check_without_annotations(self):


### PR DESCRIPTION
Creating test list annotations handles cases where lists exceed 64kB. Lists are then split into multiple annotations (chunks). These annotation lists are read by the action running on later commits. However, reading multiple chunks is not implemented:

```
publish - ERROR - Found multiple annotation with all tests in check run 2668777005
```

Changes:
- [x] provides individual title and message when list is split across multiple annotations
- [x] properly reads all chunks and concatenates them to the original single list of tests
- [x] removes some redundancy between methods creating all-tests and skipped-tests lists