### PR TITLE
Count disabled tests as skipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ The symbols have the following meaning:
 |<img src="https://github.githubassets.com/images/icons/emoji/unicode/1f525.png" height="20"/>|An erroneous test or run|
 |<img src="https://github.githubassets.com/images/icons/emoji/unicode/23f1.png" height="20"/>|The duration of all tests or runs|
 
+***Note:*** For simplicity, "disabled" tests count towards "skipped" tests.
+
 ## Configuration
 
 Files can be selected via the `files` option, which is optional and defaults to `*.xml` in the current working directory.

--- a/python/publish/__init__.py
+++ b/python/publish/__init__.py
@@ -585,7 +585,7 @@ def get_case_messages(case_results: UnitTestCaseResults) -> CaseMessages:
     for key in case_results:
         for state in case_results[key]:
             for case in case_results[key][state]:
-                message = case.message if case.result == 'skipped' else case.content
+                message = case.message if case.result in ['skipped', 'disabled'] else case.content
                 messages[key][state][message].append(case)
     return CaseMessages(messages)
 

--- a/python/publish/unittestresults.py
+++ b/python/publish/unittestresults.py
@@ -268,7 +268,7 @@ def get_test_results(parsed_results: ParsedUnitTestResultsWithCommit,
     :return: unit test result statistics
     """
     cases = parsed_results.cases
-    cases_skipped = [case for case in cases if case.result == 'skipped']
+    cases_skipped = [case for case in cases if case.result in ['skipped', 'disabled']]
     cases_failures = [case for case in cases if case.result == 'failure']
     cases_errors = [case for case in cases if case.result == 'error']
     cases_time = sum([case.time or 0 for case in cases])
@@ -277,14 +277,14 @@ def get_test_results(parsed_results: ParsedUnitTestResultsWithCommit,
     cases_results = UnitTestCaseResults()
     for case in cases:
         key = (case.test_file if dedup_classes_by_file_name else None, case.class_name, case.test_name)
-        cases_results[key][case.result].append(case)
+        cases_results[key][case.result if case.result != 'disabled' else 'skipped'].append(case)
 
     test_results = dict()
     for test, states in cases_results.items():
         test_results[test] = aggregate_states(states)
 
     tests = len(test_results)
-    tests_skipped = len([test for test, state in test_results.items() if state == 'skipped'])
+    tests_skipped = len([test for test, state in test_results.items() if state in ['skipped', 'disabled']])
     tests_failures = len([test for test, state in test_results.items() if state == 'failure'])
     tests_errors = len([test for test, state in test_results.items() if state == 'error'])
 

--- a/python/test/files/disabled.xml
+++ b/python/test/files/disabled.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name='failing tests' tests='31' disabled='5' errors='1' failures='19' skipped='0' time='0.002'>
+    <testsuite name='factorial' tests='17' disabled='5' failures='5' errors='1' skipped='0'>
+        <testcase name='positive_arguments_must_produce_expected_result[0]' status='passed' time='0'/>
+        <testcase name='factorial_of_value_from_fixture' status='failed' time='0'>
+            <failure message='/home/ivan/prj/tst/tests/failed/main.cpp:72: error: check_eq(3628800, 3628801)'/>
+        </testcase>
+        <testcase name='factorial_of_value_from_fixture[3]' status='passed' time='0'/>
+        <testcase name='factorial_of_value_from_fixture[2]' status='passed' time='0'/>
+        <testcase name='disabled_test' status='disabled' time='0'/>
+        <testcase name='positive_arguments_must_produce_expected_result' status='failed' time='0'>
+            <failure message='/home/ivan/prj/tst/tests/failed/main.cpp:45: error: check_ne(6, 6)hello world!'/>
+        </testcase>
+        <testcase name='test_which_throws_unknown_exception' status='errored' time='0'>
+            <error message='uncaught (anonymous namespace)::some_unknown_exception'/>
+        </testcase>
+        <testcase name='positive_arguments_must_produce_expected_result[2]' status='failed' time='0.001'>
+            <failure message='/home/ivan/prj/tst/tests/failed/main.cpp:85: error: check(false)'/>
+        </testcase>
+        <testcase name='positive_arguments_must_produce_expected_result[3]' status='passed' time='0'/>
+        <testcase name='factorial_of_value_from_fixture[0]' status='failed' time='0'>
+            <failure message='/home/ivan/prj/tst/tests/failed/main.cpp:109: error: expected 2'/>
+        </testcase>
+        <testcase name='disabled_param_test[0]' status='disabled' time='0'/>
+        <testcase name='disabled_param_test[1]' status='disabled' time='0'/>
+        <testcase name='disabled_param_test[2]' status='disabled' time='0'/>
+        <testcase name='test_which_fails_check_eq_with_custom_message' status='failed' time='0'>
+            <failure message='/home/ivan/prj/tst/tests/failed/main.cpp:62: error: check_eq(6, 7)hello world!'/>
+        </testcase>
+        <testcase name='disabled_param_test[3]' status='disabled' time='0'/>
+        <testcase name='positive_arguments_must_produce_expected_result[1]' status='passed' time='0'/>
+        <testcase name='factorial_of_value_from_fixture[1]' status='passed' time='0'/>
+    </testsuite>
+    <testsuite name='failing_checks' tests='14' disabled='0' failures='14' errors='0' skipped='0'>
+        <testcase name='check_ge_print' status='failed' time='0'>
+            <failure message='/home/ivan/prj/tst/tests/failed/checks.cpp:59: error: check_ge(2, 3)failed!'/>
+        </testcase>
+        <testcase name='check_ge' status='failed' time='0'>
+            <failure message='/home/ivan/prj/tst/tests/failed/checks.cpp:55: error: check_ge(2, 3)Hello world!'/>
+        </testcase>
+        <testcase name='check_gt_print' status='failed' time='0'>
+            <failure message='/home/ivan/prj/tst/tests/failed/checks.cpp:43: error: check_gt(2, 2)failed!'/>
+        </testcase>
+        <testcase name='check_lt_print' status='failed' time='0'>
+            <failure message='/home/ivan/prj/tst/tests/failed/checks.cpp:35: error: check_lt(2, 2)failed!'/>
+        </testcase>
+        <testcase name='check_print' status='failed' time='0'>
+            <failure message='/home/ivan/prj/tst/tests/failed/checks.cpp:11: error: failed!'/>
+        </testcase>
+        <testcase name='check_gt' status='failed' time='0'>
+            <failure message='/home/ivan/prj/tst/tests/failed/checks.cpp:39: error: check_gt(2, 2)Hello world!'/>
+        </testcase>
+        <testcase name='check' status='failed' time='0'>
+            <failure message='/home/ivan/prj/tst/tests/failed/checks.cpp:7: error: Hello world!'/>
+        </testcase>
+        <testcase name='check_le_print' status='failed' time='0'>
+            <failure message='/home/ivan/prj/tst/tests/failed/checks.cpp:51: error: check_le(2, 1)failed!'/>
+        </testcase>
+        <testcase name='check_eq' status='failed' time='0'>
+            <failure message='/home/ivan/prj/tst/tests/failed/checks.cpp:15: error: check_eq(1, 2)Hello world!'/>
+        </testcase>
+        <testcase name='check_eq_print' status='failed' time='0'>
+            <failure message='/home/ivan/prj/tst/tests/failed/checks.cpp:19: error: check_eq(1, 2)failed!'/>
+        </testcase>
+        <testcase name='check_le' status='failed' time='0'>
+            <failure message='/home/ivan/prj/tst/tests/failed/checks.cpp:47: error: check_le(2, 1)Hello world!'/>
+        </testcase>
+        <testcase name='check_ne' status='failed' time='0'>
+            <failure message='/home/ivan/prj/tst/tests/failed/checks.cpp:23: error: check_ne(2, 2)Hello world!'/>
+        </testcase>
+        <testcase name='check_lt' status='failed' time='0'>
+            <failure message='/home/ivan/prj/tst/tests/failed/checks.cpp:31: error: check_lt(2, 2)Hello world!'/>
+        </testcase>
+        <testcase name='check_ne_print' status='failed' time='0.001'>
+            <failure message='/home/ivan/prj/tst/tests/failed/checks.cpp:27: error: check_ne(2, 2)failed!'/>
+        </testcase>
+    </testsuite>
+</testsuites>

--- a/python/test/test_junit.py
+++ b/python/test/test_junit.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from junitparser import JUnitXml, Element, version
 
-from publish.junit import parse_junit_xml_files, get_results, get_result, get_content, get_message
+from publish.junit import parse_junit_xml_files, get_results, get_result, get_content, get_message, Disabled
 from publish.unittestresults import ParsedUnitTestResults, UnitTestCase, ParseError
 
 
@@ -454,6 +454,51 @@ class TestJunit(unittest.TestCase):
         self.assertEqual("skipped", junit.cases[2].result)
         self.assertEqual("success", junit.cases[3].result)
 
+    def test_parse_junit_xml_file_with_disabled_tests(self):
+        self.assertEqual(
+            parse_junit_xml_files(['files/disabled.xml']),
+            ParsedUnitTestResults(
+                cases=[UnitTestCase(result_file='files/disabled.xml', test_file=None, line=None, class_name=None, test_name='positive_arguments_must_produce_expected_result[0]', result='success', message=None, content=None, time=0.0),
+                       UnitTestCase(result_file='files/disabled.xml', test_file=None, line=None, class_name=None, test_name='factorial_of_value_from_fixture', result='failure', message='/home/ivan/prj/tst/tests/failed/main.cpp:72: error: check_eq(3628800, 3628801)', content=None, time=0.0),
+                       UnitTestCase(result_file='files/disabled.xml', test_file=None, line=None, class_name=None, test_name='factorial_of_value_from_fixture[3]', result='success', message=None, content=None, time=0.0),
+                       UnitTestCase(result_file='files/disabled.xml', test_file=None, line=None, class_name=None, test_name='factorial_of_value_from_fixture[2]', result='success', message=None, content=None, time=0.0),
+                       UnitTestCase(result_file='files/disabled.xml', test_file=None, line=None, class_name=None, test_name='disabled_test', result='disabled', message=None, content=None, time=0.0),
+                       UnitTestCase(result_file='files/disabled.xml', test_file=None, line=None, class_name=None, test_name='positive_arguments_must_produce_expected_result', result='failure', message='/home/ivan/prj/tst/tests/failed/main.cpp:45: error: check_ne(6, 6)hello world!', content=None, time=0.0),
+                       UnitTestCase(result_file='files/disabled.xml', test_file=None, line=None, class_name=None, test_name='test_which_throws_unknown_exception', result='error', message='uncaught (anonymous namespace)::some_unknown_exception', content=None, time=0.0),
+                       UnitTestCase(result_file='files/disabled.xml', test_file=None, line=None, class_name=None, test_name='positive_arguments_must_produce_expected_result[2]', result='failure', message='/home/ivan/prj/tst/tests/failed/main.cpp:85: error: check(false)', content=None, time=0.001),
+                       UnitTestCase(result_file='files/disabled.xml', test_file=None, line=None, class_name=None, test_name='positive_arguments_must_produce_expected_result[3]', result='success', message=None, content=None, time=0.0),
+                       UnitTestCase(result_file='files/disabled.xml', test_file=None, line=None, class_name=None, test_name='factorial_of_value_from_fixture[0]', result='failure', message='/home/ivan/prj/tst/tests/failed/main.cpp:109: error: expected 2', content=None, time=0.0),
+                       UnitTestCase(result_file='files/disabled.xml', test_file=None, line=None, class_name=None, test_name='disabled_param_test[0]', result='disabled', message=None, content=None, time=0.0),
+                       UnitTestCase(result_file='files/disabled.xml', test_file=None, line=None, class_name=None, test_name='disabled_param_test[1]', result='disabled', message=None, content=None, time=0.0),
+                       UnitTestCase(result_file='files/disabled.xml', test_file=None, line=None, class_name=None, test_name='disabled_param_test[2]', result='disabled', message=None, content=None, time=0.0),
+                       UnitTestCase(result_file='files/disabled.xml', test_file=None, line=None, class_name=None, test_name='test_which_fails_check_eq_with_custom_message', result='failure', message='/home/ivan/prj/tst/tests/failed/main.cpp:62: error: check_eq(6, 7)hello world!', content=None, time=0.0),
+                       UnitTestCase(result_file='files/disabled.xml', test_file=None, line=None, class_name=None, test_name='disabled_param_test[3]', result='disabled', message=None, content=None, time=0.0),
+                       UnitTestCase(result_file='files/disabled.xml', test_file=None, line=None, class_name=None, test_name='positive_arguments_must_produce_expected_result[1]', result='success', message=None, content=None, time=0.0),
+                       UnitTestCase(result_file='files/disabled.xml', test_file=None, line=None, class_name=None, test_name='factorial_of_value_from_fixture[1]', result='success', message=None, content=None, time=0.0),
+                       UnitTestCase(result_file='files/disabled.xml', test_file=None, line=None, class_name=None, test_name='check_ge_print', result='failure', message='/home/ivan/prj/tst/tests/failed/checks.cpp:59: error: check_ge(2, 3)failed!', content=None, time=0.0),
+                       UnitTestCase(result_file='files/disabled.xml', test_file=None, line=None, class_name=None, test_name='check_ge', result='failure', message='/home/ivan/prj/tst/tests/failed/checks.cpp:55: error: check_ge(2, 3)Hello world!', content=None, time=0.0),
+                       UnitTestCase(result_file='files/disabled.xml', test_file=None, line=None, class_name=None, test_name='check_gt_print', result='failure', message='/home/ivan/prj/tst/tests/failed/checks.cpp:43: error: check_gt(2, 2)failed!', content=None, time=0.0),
+                       UnitTestCase(result_file='files/disabled.xml', test_file=None, line=None, class_name=None, test_name='check_lt_print', result='failure', message='/home/ivan/prj/tst/tests/failed/checks.cpp:35: error: check_lt(2, 2)failed!', content=None, time=0.0),
+                       UnitTestCase(result_file='files/disabled.xml', test_file=None, line=None, class_name=None, test_name='check_print', result='failure', message='/home/ivan/prj/tst/tests/failed/checks.cpp:11: error: failed!', content=None, time=0.0),
+                       UnitTestCase(result_file='files/disabled.xml', test_file=None, line=None, class_name=None, test_name='check_gt', result='failure', message='/home/ivan/prj/tst/tests/failed/checks.cpp:39: error: check_gt(2, 2)Hello world!', content=None, time=0.0),
+                       UnitTestCase(result_file='files/disabled.xml', test_file=None, line=None, class_name=None, test_name='check', result='failure', message='/home/ivan/prj/tst/tests/failed/checks.cpp:7: error: Hello world!', content=None, time=0.0),
+                       UnitTestCase(result_file='files/disabled.xml', test_file=None, line=None, class_name=None, test_name='check_le_print', result='failure', message='/home/ivan/prj/tst/tests/failed/checks.cpp:51: error: check_le(2, 1)failed!', content=None, time=0.0),
+                       UnitTestCase(result_file='files/disabled.xml', test_file=None, line=None, class_name=None, test_name='check_eq', result='failure', message='/home/ivan/prj/tst/tests/failed/checks.cpp:15: error: check_eq(1, 2)Hello world!', content=None, time=0.0),
+                       UnitTestCase(result_file='files/disabled.xml', test_file=None, line=None, class_name=None, test_name='check_eq_print', result='failure', message='/home/ivan/prj/tst/tests/failed/checks.cpp:19: error: check_eq(1, 2)failed!', content=None, time=0.0),
+                       UnitTestCase(result_file='files/disabled.xml', test_file=None, line=None, class_name=None, test_name='check_le', result='failure', message='/home/ivan/prj/tst/tests/failed/checks.cpp:47: error: check_le(2, 1)Hello world!', content=None, time=0.0),
+                       UnitTestCase(result_file='files/disabled.xml', test_file=None, line=None, class_name=None, test_name='check_ne', result='failure', message='/home/ivan/prj/tst/tests/failed/checks.cpp:23: error: check_ne(2, 2)Hello world!', content=None, time=0.0),
+                       UnitTestCase(result_file='files/disabled.xml', test_file=None, line=None, class_name=None, test_name='check_lt', result='failure', message='/home/ivan/prj/tst/tests/failed/checks.cpp:31: error: check_lt(2, 2)Hello world!', content=None, time=0.0),
+                       UnitTestCase(result_file='files/disabled.xml', test_file=None, line=None, class_name=None, test_name='check_ne_print', result='failure', message='/home/ivan/prj/tst/tests/failed/checks.cpp:27: error: check_ne(2, 2)failed!', content=None, time=0.001)],
+                files=1,
+                errors=[],
+                suite_errors=1,
+                suite_failures=19,
+                suite_skipped=5,
+                suite_tests=31,
+                suite_time=0,
+                suites=2
+            ))
+
     def test_get_results(self):
         success = TestElement('success')
         skipped = TestElement('skipped')
@@ -477,6 +522,24 @@ class TestJunit(unittest.TestCase):
         for results, expected in tests:
             with self.subTest(results=results):
                 actual = get_results(results)
+                self.assertEqual(expected, actual)
+
+    def test_get_results_with_disabled_status(self):
+        disabled = Disabled()
+        success = TestElement('success')
+        skipped = TestElement('skipped')
+        failure = TestElement('failure')
+        error = TestElement('error')
+        tests = [
+            ([], [disabled]),
+            ([success], [success]),
+            ([skipped], [skipped]),
+            ([failure], [failure]),
+            ([error], [error]),
+        ]
+        for results, expected in tests:
+            with self.subTest(results=results):
+                actual = get_results(results, 'disabled')
                 self.assertEqual(expected, actual)
 
     def test_get_result(self):

--- a/python/test/test_unittestresults.py
+++ b/python/test/test_unittestresults.py
@@ -287,6 +287,39 @@ class TestUnitTestResults(unittest.TestCase):
             commit='commit'
         ))
 
+    def test_get_test_results_with_disabled_cases(self):
+        self.assertEqual(get_test_results(ParsedUnitTestResultsWithCommit(
+            files=1,
+            errors=errors,
+            suites=2, suite_tests=3, suite_skipped=4, suite_failures=5, suite_errors=6, suite_time=7,
+            cases=[
+                UnitTestCase(result_file='result', test_file='test', line=123, class_name='class1', test_name='test1', result='success', message='message1', content='content1', time=1),
+                UnitTestCase(result_file='result', test_file='test', line=123, class_name='class1', test_name='test2', result='skipped', message='message2', content='content2', time=2),
+                UnitTestCase(result_file='result', test_file='test', line=123, class_name='class1', test_name='test3', result='failure', message='message3', content='content3', time=3),
+                UnitTestCase(result_file='result', test_file='test', line=123, class_name='class2', test_name='test1', result='error', message='message4', content='content4', time=4),
+                UnitTestCase(result_file='result', test_file='test', line=123, class_name='class2', test_name='test2', result='disabled', message='message5', content='content5', time=5),
+                UnitTestCase(result_file='result', test_file='test', line=123, class_name='class2', test_name='test3', result='failure', message='message6', content='content6', time=6),
+                UnitTestCase(result_file='result', test_file='test', line=123, class_name='class2', test_name='test4', result='failure', message='message7', content='content7', time=7),
+            ],
+            commit='commit'
+        ), False), UnitTestResults(
+            files=1,
+            errors=errors,
+            suites=2, suite_tests=3, suite_skipped=4, suite_failures=5, suite_errors=6, suite_time=7,
+            cases=7, cases_skipped=2, cases_failures=3, cases_errors=1, cases_time=28,
+            case_results=UnitTestCaseResults([
+                ((None, 'class1', 'test1'), dict(success=[UnitTestCase(result_file='result', test_file='test', line=123, class_name='class1', test_name='test1', result='success', message='message1', content='content1', time=1)])),
+                ((None, 'class1', 'test2'), dict(skipped=[UnitTestCase(result_file='result', test_file='test', line=123, class_name='class1', test_name='test2', result='skipped', message='message2', content='content2', time=2)])),
+                ((None, 'class1', 'test3'), dict(failure=[UnitTestCase(result_file='result', test_file='test', line=123, class_name='class1', test_name='test3', result='failure', message='message3', content='content3', time=3)])),
+                ((None, 'class2', 'test1'), dict(error=[UnitTestCase(result_file='result', test_file='test', line=123, class_name='class2', test_name='test1', result='error', message='message4', content='content4', time=4)])),
+                ((None, 'class2', 'test2'), dict(skipped=[UnitTestCase(result_file='result', test_file='test', line=123, class_name='class2', test_name='test2', result='disabled', message='message5', content='content5', time=5)])),
+                ((None, 'class2', 'test3'), dict(failure=[UnitTestCase(result_file='result', test_file='test', line=123, class_name='class2', test_name='test3', result='failure', message='message6', content='content6', time=6)])),
+                ((None, 'class2', 'test4'), dict(failure=[UnitTestCase(result_file='result', test_file='test', line=123, class_name='class2', test_name='test4', result='failure', message='message7', content='content7', time=7)])),
+            ]),
+            tests=7, tests_skipped=2, tests_failures=3, tests_errors=1,
+            commit='commit'
+        ))
+
     def test_get_stats(self):
         self.assertEqual(get_stats(UnitTestResults(
             files=1,


### PR DESCRIPTION
Fixes #143 partially by including disabled tests in skipped tests. Before, disabled tests where not recognized as such at all and considered passed tests. Since junitparser packages does not support disabled test cases either, introducing this notion here is a bit hacky. Once the package supported that, changes from this PR should be tidied up.