### PR TITLE
The github_token input has a default value and is not required

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
   github_token:
     description: 'GitHub API Access Token'
     default: ${{ github.token }}
-    required: true
+    required: false
   github_retries:
     description: 'Requests to the GitHub API are retried this number of times. The value must be a positive integer or zero.'
     default: '10'

--- a/composite/action.yml
+++ b/composite/action.yml
@@ -5,7 +5,7 @@ inputs:
   github_token:
     description: 'GitHub API Access Token'
     default: ${{ github.token }}
-    required: true
+    required: false
   github_retries:
     description: 'Requests to the GitHub API are retried this number of times. The value must be a positive integer or zero.'
     default: '10'


### PR DESCRIPTION
Hello

The `github_token` input parameter has a default value and is not required.
It makes my `vscode` yell at me:

![image](https://user-images.githubusercontent.com/28388442/126175043-1908f9ef-94eb-45a0-abbb-bf42ceea60d0.png)
