### PR TITLE
Retry all 403 responses

### DIFF
--- a/python/publish_unit_test_results.py
+++ b/python/publish_unit_test_results.py
@@ -37,7 +37,10 @@ def get_github(token: str, url: str, retries: int, backoff_factor: float) -> git
     retry = Retry(total=retries,
                   backoff_factor=backoff_factor,
                   allowed_methods=Retry.DEFAULT_ALLOWED_METHODS.union({'GET', 'POST'}),
-                  status_forcelist=range(500, 600))
+                  # 403 is too broad to be retried, but GitHub API signals rate limits via 403
+                  # urllib3 Retry does not allow to consider the HTTP message, only status code
+                  # so we retry all 403, which will respect HTTP Retry-After header
+                  status_forcelist=[403] + list(range(500, 600)))
     return github.Github(login_or_token=token, base_url=url, retry=retry)
 
 

--- a/python/test/test_github.py
+++ b/python/test/test_github.py
@@ -4,6 +4,7 @@ import time
 import unittest
 from multiprocessing import Process
 
+import github.GithubException
 import requests.exceptions
 from flask import Flask
 
@@ -41,8 +42,11 @@ class TestGitHub(unittest.TestCase):
         server.terminate()
         server.join(2)
 
+    test_http_status_to_retry = [403, 500, 502, 503, 504]
+    test_http_status_to_not_retry = [400, 401, 404, 429]
+
     def test_github_get_retry(self):
-        for status in [500, 502, 503, 504]:
+        for status in self.test_http_status_to_retry:
             with self.subTest(status=status):
                 app = Flask(self.test_github_post_retry.__name__)
 
@@ -52,7 +56,7 @@ class TestGitHub(unittest.TestCase):
 
                 @app.route('/api/repos/<owner>/<repo>')
                 def repo(owner: str, repo: str):
-                    return 'null', status
+                    return f'{{"message": "{status}"}}', status
 
                 server = self.start_api(app)
                 try:
@@ -64,8 +68,29 @@ class TestGitHub(unittest.TestCase):
                 finally:
                     self.stop_api(server)
 
+    def test_github_get_no_retry(self):
+        for status in self.test_http_status_to_not_retry:
+            with self.subTest(status=status):
+                app = Flask(self.test_github_post_retry.__name__)
+
+                @app.route('/health')
+                def health():
+                    return {'health': 'alive'}
+
+                @app.route('/api/repos/<owner>/<repo>')
+                def repo(owner: str, repo: str):
+                    return f'{{"message": "{status}"}}', status
+
+                server = self.start_api(app)
+                try:
+                    with self.assertRaises(github.GithubException) as context:
+                        self.gh.get_repo('owner/repo')
+                    self.assertEquals(status, context.exception.args[0])
+                finally:
+                    self.stop_api(server)
+
     def test_github_post_retry(self):
-        for status in [500, 502, 503, 504]:
+        for status in self.test_http_status_to_retry:
             with self.subTest(status=status):
                 app = Flask(self.test_github_post_retry.__name__)
 
@@ -79,7 +104,7 @@ class TestGitHub(unittest.TestCase):
 
                 @app.route('/api/repos/<owner>/<repo>/check-runs', methods=['POST'])
                 def check_runs(owner: str, repo: str):
-                    return 'null', status
+                    return f'{{"message": "{status}"}}', status
 
                 @app.route('/api/repos/<owner>/<repo>/pulls/<int:number>')
                 def pull(owner: str, repo: str, number: int):
@@ -87,11 +112,11 @@ class TestGitHub(unittest.TestCase):
 
                 @app.route('/api/repos/<owner>/<repo>/issues/<int:number>/comments', methods=['POST'])
                 def comment(owner: str, repo: str, number: int):
-                    return 'null', status
+                    return f'{{"message": "{status}"}}', status
 
                 @app.route('/api/graphql', methods=['POST'])
                 def graphql():
-                    return 'null', status
+                    return f'{{"message": "{status}"}}', status
 
                 server = self.start_api(app)
                 try:
@@ -123,6 +148,40 @@ class TestGitHub(unittest.TestCase):
                         )
                     self.assertIn(f"Max retries exceeded with url: /api/graphql", context.exception.args[0].args[0])
                     self.assertIn(f"Caused by ResponseError('too many {status} error responses'", context.exception.args[0].args[0])
+
+                finally:
+                    self.stop_api(server)
+
+    def test_github_post_no_retry(self):
+        for status in self.test_http_status_to_not_retry:
+            with self.subTest(status=status):
+                app = Flask(self.test_github_post_retry.__name__)
+
+                @app.route('/health')
+                def health():
+                    return {'health': 'alive'}
+
+                @app.route('/api/repos/<owner>/<repo>')
+                def repo(owner: str, repo: str):
+                    return {'id': 1234, 'name': repo, 'full_name': '/'.join([owner, repo]), 'url': '/'.join([self.base_url, 'repos', owner, repo])}
+
+                @app.route('/api/repos/<owner>/<repo>/check-runs', methods=['POST'])
+                def check_runs(owner: str, repo: str):
+                    return f'{{"message": "{status}"}}', status
+
+                server = self.start_api(app)
+                try:
+                    repo = self.gh.get_repo('owner/repo')
+                    expected = {'full_name': 'owner/repo', 'id': 1234, 'name': 'repo', 'url': 'http://localhost:12380/api/repos/owner/repo'}
+                    self.assertEqual(expected, repo.raw_data)
+
+                    with self.assertRaises(github.GithubException) as context:
+                        repo.create_check_run(name='check_name',
+                                              head_sha='sha',
+                                              status='completed',
+                                              conclusion='success',
+                                              output={})
+                    self.assertEquals(status, context.exception.args[0])
 
                 finally:
                     self.stop_api(server)


### PR DESCRIPTION
This explicitly implements #150 as those exceptions still occur even with throttled API calls.