### PR TITLE
Pick best check run

### DIFF
--- a/python/publish/__init__.py
+++ b/python/publish/__init__.py
@@ -11,7 +11,10 @@ from publish.unittestresults import Numeric, UnitTestCaseResults, UnitTestRunRes
     UnitTestRunDeltaResults, UnitTestRunResultsOrDeltaResults, ParseError
 
 logger = logging.getLogger('publish')
-digest_prefix = '[test-results]:data:application/gzip;base64,'
+digest_prefix = '[test-results]:data:'
+digest_mime_type = 'application/gzip'
+digest_encoding = 'base64'
+digest_header = f'{digest_prefix}{digest_mime_type};{digest_encoding},'
 digit_space = '  '
 punctuation_space = ' '
 
@@ -594,7 +597,7 @@ def get_long_summary_with_digest_md(stats: UnitTestRunResultsOrDeltaResults,
         raise ValueError('stats must be UnitTestRunResults when no digest_stats is given')
     summary = get_long_summary_md(stats)
     digest = get_digest_from_stats(stats if digest_stats is None else digest_stats)
-    return f'{summary}\n{digest_prefix}{digest}'
+    return f'{summary}\n{digest_header}{digest}'
 
 
 def get_case_messages(case_results: UnitTestCaseResults) -> CaseMessages:

--- a/python/test/test_publisher.py
+++ b/python/test/test_publisher.py
@@ -1,6 +1,6 @@
 import unittest
 from collections.abc import Collection
-import datetime
+from datetime import datetime, timezone
 
 import github.CheckRun
 import mock
@@ -533,19 +533,19 @@ class TestPublisher(unittest.TestCase):
         self.do_test_get_check_run_from_list([], None)
 
     def test_get_check_run_from_list_many(self):
-        expected = self.mock_check_run(name='Check Name', status='completed', started_at=datetime.datetime.fromisoformat('2021-03-19T12:02:04'), summary='summary\n[test-results]:data:application/gzip;base64,digest')
+        expected = self.mock_check_run(name='Check Name', status='completed', started_at=datetime(2021, 3, 19, 12, 2, 4, tzinfo=timezone.utc), summary='summary\n[test-results]:data:application/gzip;base64,digest')
         runs = [
-            self.mock_check_run(name='Other title', status='completed', started_at=datetime.datetime.fromisoformat('2021-03-19T12:02:04'), summary='summary\n[test-results]:data:application/gzip;base64,digest'),
-            self.mock_check_run(name='Check Name', status='other status', started_at=datetime.datetime.fromisoformat('2021-03-19T12:02:04'), summary='summary\n[test-results]:data:application/gzip;base64,digest'),
-            self.mock_check_run(name='Check Name', status='completed', started_at=datetime.datetime.fromisoformat('2021-03-19T12:00:00'), summary='summary\n[test-results]:data:application/gzip;base64,digest'),
+            self.mock_check_run(name='Other title', status='completed', started_at=datetime(2021, 3, 19, 12, 2, 4, tzinfo=timezone.utc), summary='summary\n[test-results]:data:application/gzip;base64,digest'),
+            self.mock_check_run(name='Check Name', status='other status', started_at=datetime(2021, 3, 19, 12, 2, 4, tzinfo=timezone.utc), summary='summary\n[test-results]:data:application/gzip;base64,digest'),
+            self.mock_check_run(name='Check Name', status='completed', started_at=datetime(2021, 3, 19, 12, 0, 0, tzinfo=timezone.utc), summary='summary\n[test-results]:data:application/gzip;base64,digest'),
             expected,
-            self.mock_check_run(name='Check Name', status='completed', started_at=datetime.datetime.fromisoformat('2021-03-19T12:00:00'), summary='no digest')
+            self.mock_check_run(name='Check Name', status='completed', started_at=datetime(2021, 3, 19, 12, 2, 4, tzinfo=timezone.utc), summary='no digest')
         ]
         name = runs[0].name
         self.do_test_get_check_run_from_list(runs, expected)
 
     @staticmethod
-    def mock_check_run(name: str, status: str, started_at: datetime.datetime, summary: str) -> mock.Mock:
+    def mock_check_run(name: str, status: str, started_at: datetime, summary: str) -> mock.Mock:
         run = mock.MagicMock(status=status, started_at=started_at, output=mock.MagicMock(summary=summary))
         run.name = name
         return run


### PR DESCRIPTION
Check runs for a commit include workflow job names. If those happen to have the same name as the check run of the result, then the action cannot find a single check run of the base commit. This filters check runs further.