### PR TITLE
Fixing issue when summary is None

### DIFF
--- a/python/publish/publisher.py
+++ b/python/publish/publisher.py
@@ -155,7 +155,7 @@ class Publisher:
             return runs[0]
 
         # filter based on summary
-        runs = [run for run in runs if digest_prefix in run.output.summary]
+        runs = [run for run in runs if run.output.summary and digest_prefix in run.output.summary]
         logger.debug(f'there are {len(runs)} check runs with a test result summary')
         if len(runs) == 0:
             return None

--- a/python/test/test_publisher.py
+++ b/python/test/test_publisher.py
@@ -533,14 +533,15 @@ class TestPublisher(unittest.TestCase):
         self.do_test_get_check_run_from_list([], None)
 
     def test_get_check_run_from_list_many(self):
-        expected = self.mock_check_run(name='Check Name', status='completed', started_at=datetime(2021, 3, 19, 12, 2, 4, tzinfo=timezone.utc), summary='summary\n[test-results]:data:application/gzip;base64,digest')
         runs = [
             self.mock_check_run(name='Other title', status='completed', started_at=datetime(2021, 3, 19, 12, 2, 4, tzinfo=timezone.utc), summary='summary\n[test-results]:data:application/gzip;base64,digest'),
             self.mock_check_run(name='Check Name', status='other status', started_at=datetime(2021, 3, 19, 12, 2, 4, tzinfo=timezone.utc), summary='summary\n[test-results]:data:application/gzip;base64,digest'),
             self.mock_check_run(name='Check Name', status='completed', started_at=datetime(2021, 3, 19, 12, 0, 0, tzinfo=timezone.utc), summary='summary\n[test-results]:data:application/gzip;base64,digest'),
-            expected,
-            self.mock_check_run(name='Check Name', status='completed', started_at=datetime(2021, 3, 19, 12, 2, 4, tzinfo=timezone.utc), summary='no digest')
+            self.mock_check_run(name='Check Name', status='completed', started_at=datetime(2021, 3, 19, 12, 2, 4, tzinfo=timezone.utc), summary='summary\n[test-results]:data:application/gzip;base64,digest'),
+            self.mock_check_run(name='Check Name', status='completed', started_at=datetime(2021, 3, 19, 12, 2, 4, tzinfo=timezone.utc), summary='no digest'),
+            self.mock_check_run(name='Check Name', status='completed', started_at=datetime(2021, 3, 19, 12, 2, 4, tzinfo=timezone.utc), summary=None)
         ]
+        expected = runs[3]
         name = runs[0].name
         self.do_test_get_check_run_from_list(runs, expected)
 


### PR DESCRIPTION
When summary is `None` the new method `get_check_run_from_list` fails checking for contained string. This is fixed and tested.