### PR TITLE
Do not compare commit to itself

### DIFF
--- a/python/publish/publisher.py
+++ b/python/publish/publisher.py
@@ -292,6 +292,8 @@ class Publisher:
         base_check_run = None
         if self._settings.compare_earlier:
             base_commit_sha = self.get_base_commit_sha(pull_request)
+            if stats.commit == base_commit_sha:
+                base_commit_sha = None
             logger.debug(f'comparing against base={base_commit_sha}')
             base_check_run = self.get_check_run(base_commit_sha)
         base_stats = self.get_stats_from_check_run(base_check_run) if base_check_run is not None else None

--- a/python/test/test_publisher.py
+++ b/python/test/test_publisher.py
@@ -444,6 +444,46 @@ class TestPublisher(unittest.TestCase):
         self.assertEqual(('## title\nbody', ), args)
         self.assertEqual({}, kwargs)
 
+    def test_publish_comment_compare_with_None(self):
+        pr = mock.MagicMock()
+        cr = mock.MagicMock()
+        stats = self.stats
+        cases = UnitTestCaseResults(self.cases)
+        settings = self.create_settings(comment_mode=comment_mode_create, compare_earlier=True)
+        publisher = mock.MagicMock(Publisher)
+        publisher._settings = settings
+        publisher.get_check_run = mock.Mock(return_value=None)
+        publisher.get_base_commit_sha = mock.Mock(return_value=None)
+        publisher.get_test_lists_from_check_run = mock.Mock(return_value=(None, None))
+        with mock.patch('publish.publisher.get_long_summary_md', return_value='body'):
+            Publisher.publish_comment(publisher, 'title', stats, pr, cr, cases)
+        mock_calls = publisher.mock_calls
+
+        self.assertEqual(3, len(mock_calls))
+
+        (method, args, kwargs) = mock_calls[0]
+        self.assertEqual('get_base_commit_sha', method)
+        self.assertEqual((pr, ), args)
+        self.assertEqual({}, kwargs)
+
+        (method, args, kwargs) = mock_calls[1]
+        self.assertEqual('get_check_run', method)
+        self.assertEqual((None, ), args)
+        self.assertEqual({}, kwargs)
+
+        (method, args, kwargs) = mock_calls[2]
+        self.assertEqual('get_test_lists_from_check_run', method)
+        self.assertEqual((None, ), args)
+        self.assertEqual({}, kwargs)
+
+        mock_calls = pr.mock_calls
+        self.assertEqual(1, len(mock_calls))
+
+        (method, args, kwargs) = mock_calls[0]
+        self.assertEqual('create_issue_comment', method)
+        self.assertEqual(('## title\nbody', ), args)
+        self.assertEqual({}, kwargs)
+
     def do_test_publish_comment_with_reuse_comment(self, one_exists: bool):
         pr = mock.MagicMock()
         cr = mock.MagicMock()


### PR DESCRIPTION
Avoids the action to compare a commit with itself in a pull request comment (see #148).