### PR TITLE
Do not publish a pr comment when we would compare the commit to itself

### DIFF
--- a/python/publish/publisher.py
+++ b/python/publish/publisher.py
@@ -293,7 +293,9 @@ class Publisher:
         if self._settings.compare_earlier:
             base_commit_sha = self.get_base_commit_sha(pull_request)
             if stats.commit == base_commit_sha:
-                base_commit_sha = None
+                # we do not publish a comment when we compare the commit to itself
+                # that would overwrite earlier comments without change stats
+                return pull_request
             logger.debug(f'comparing against base={base_commit_sha}')
             base_check_run = self.get_check_run(base_commit_sha)
         base_stats = self.get_stats_from_check_run(base_check_run) if base_check_run is not None else None

--- a/python/test/test_publisher.py
+++ b/python/test/test_publisher.py
@@ -419,30 +419,15 @@ class TestPublisher(unittest.TestCase):
             Publisher.publish_comment(publisher, 'title', stats, pr, cr, cases)
         mock_calls = publisher.mock_calls
 
-        self.assertEqual(3, len(mock_calls))
+        self.assertEqual(1, len(mock_calls))
 
         (method, args, kwargs) = mock_calls[0]
         self.assertEqual('get_base_commit_sha', method)
         self.assertEqual((pr, ), args)
         self.assertEqual({}, kwargs)
 
-        (method, args, kwargs) = mock_calls[1]
-        self.assertEqual('get_check_run', method)
-        self.assertEqual((None, ), args)
-        self.assertEqual({}, kwargs)
-
-        (method, args, kwargs) = mock_calls[2]
-        self.assertEqual('get_test_lists_from_check_run', method)
-        self.assertEqual((None, ), args)
-        self.assertEqual({}, kwargs)
-
         mock_calls = pr.mock_calls
-        self.assertEqual(1, len(mock_calls))
-
-        (method, args, kwargs) = mock_calls[0]
-        self.assertEqual('create_issue_comment', method)
-        self.assertEqual(('## title\nbody', ), args)
-        self.assertEqual({}, kwargs)
+        self.assertEqual(0, len(mock_calls))
 
     def test_publish_comment_compare_with_None(self):
         pr = mock.MagicMock()


### PR DESCRIPTION
Earlier (#176) we decided not to compare to itself, but it is better not to publish a PR comment at all as it would not contain change stats and would replace earlier comments that might contain those stats.