### PR TITLE
Use unescaped strings from TestCase

### DIFF
--- a/python/publish/junit.py
+++ b/python/publish/junit.py
@@ -126,13 +126,16 @@ def parse_junit_xml_files(files: Iterable[str]) -> ParsedUnitTestResults:
                 for suite in suites
                 for case in get_cases(suite)] + cases
 
+    # junitparser HTML escapes all attributes (e.g. TestCase.name), see junitparser.junitparser.Attr
+    # we could unescape the values, or access the XML attributes instead (e.g. TestCase._elem.attrib['name'])
+    # https://github.com/weiwei/junitparser/issues/71
     cases = [
         UnitTestCase(
             result_file=result_file,
             test_file=case._elem.get('file'),
             line=int_opt(case._elem.get('line')),
-            class_name=case.classname,
-            test_name=case.name,
+            class_name=case._elem.attrib.get('classname'),
+            test_name=case._elem.attrib.get('name'),
             result=get_result(results),
             message=get_message(results),
             content=get_content(results),

--- a/python/publish/junit.py
+++ b/python/publish/junit.py
@@ -54,8 +54,8 @@ def get_message(results: Union[Element, List[Element]]) -> str:
     if isinstance(results, List):
         messages = [result._elem.attrib.get('message')
                     for result in results
-                    if result and result.message]
-        message = '\n'.join([message for message in messages if message is not None]) if messages else None
+                    if result and result._elem.attrib.get('message')]
+        message = '\n'.join(messages) if messages else None
     else:
         message = results._elem.attrib.get('message') if results else None
     return message

--- a/python/publish/junit.py
+++ b/python/publish/junit.py
@@ -1,6 +1,5 @@
 import os
 from collections import defaultdict
-from html import unescape
 from typing import Optional, Iterable, Union, Any, List
 
 from junitparser import Element, JUnitXml, TestCase, TestSuite, Skipped
@@ -49,14 +48,17 @@ def get_message(results: Union[Element, List[Element]]) -> str:
     :param results:
     :return:
     """
+    # junitparser HTML escapes all attributes (e.g. TestCase.name), see junitparser.junitparser.Attr
+    # we could unescape the values, or access the XML attributes instead (e.g. TestCase._elem.attrib['name'])
+    # https://github.com/weiwei/junitparser/issues/71
     if isinstance(results, List):
-        messages = [result.message
+        messages = [result._elem.attrib.get('message')
                     for result in results
                     if result and result.message]
-        message = '\n'.join(messages) if messages else None
+        message = '\n'.join([message for message in messages if message is not None]) if messages else None
     else:
-        message = results.message if results else None
-    return unescape(message) if message is not None else None
+        message = results._elem.attrib.get('message') if results else None
+    return message
 
 
 def get_content(results: Union[Element, List[Element]]) -> str:
@@ -66,14 +68,13 @@ def get_content(results: Union[Element, List[Element]]) -> str:
     :return:
     """
     if isinstance(results, List):
-        contents = [result._elem.text
+        contents = [result.text
                     for result in results
-                    if result is not None and result._elem is not None and result._elem.text is not None]
+                    if result is not None and result.text is not None]
         content = '\n'.join(contents) if contents else None
     else:
-        content = results._elem.text \
-            if results and results._elem and results._elem.text is not None else None
-    return unescape(content) if content is not None else None
+        content = results.text if results and results.text is not None else None
+    return content
 
 
 def parse_junit_xml_files(files: Iterable[str]) -> ParsedUnitTestResults:

--- a/python/test/files/with-xml-entities.xml
+++ b/python/test/files/with-xml-entities.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+    <testsuite>
+        <testcase name="Test with &quot;quotes&quot; in the test name" time="0.0">
+            <skipped message="A message with &quot;quotes&quot;">Content with &quot;quotes&quot;</skipped>
+        </testcase>
+        <testcase name="Test with &apos;apostrophe&apos; in the test name" time="0.0">
+            <failure  message="A message with &apos;apostrophes&apos;">Content with &apos;apostrophes&apos;</failure>
+        </testcase>
+        <testcase name="Test with &amp; in the test name" time="0.0">
+            <error message="A message with &amp;">Content with &amp;</error>
+        </testcase>
+        <testcase name="Test with &lt; and &gt; in the test name" time="0.0">
+            <skipped message="A message with &lt; and &gt;">Content with &lt; and &gt;</skipped>
+        </testcase>
+    </testsuite>
+</testsuites>

--- a/python/test/files/xml-entities-in-names.xml
+++ b/python/test/files/xml-entities-in-names.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<testsuites>
-    <testsuite>
-        <testcase name="Test with &quot;quotes&quot; in the test name" time="0.0"/>
-        <testcase name="Test with &apos;apostrophe&apos; in the test name" time="0.0"/>
-        <testcase name="Test with &amp; in the test name" time="0.0"/>
-        <testcase name="Test with &lt; and &gt; in the test name" time="0.0"/>
-    </testsuite>
-</testsuites>

--- a/python/test/files/xml-entities-in-names.xml
+++ b/python/test/files/xml-entities-in-names.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+    <testsuite>
+        <testcase name="Test with &quot;quotes&quot; in the test name" time="0.0"/>
+        <testcase name="Test with &apos;apostrophe&apos; in the test name" time="0.0"/>
+        <testcase name="Test with &amp; in the test name" time="0.0"/>
+        <testcase name="Test with &lt; and &gt; in the test name" time="0.0"/>
+    </testsuite>
+</testsuites>

--- a/python/test/test_junit.py
+++ b/python/test/test_junit.py
@@ -499,6 +499,26 @@ class TestJunit(unittest.TestCase):
                 suites=2
             ))
 
+    def test_parse_junit_xml_files_xml_entities_in_test_names(self):
+        self.assertEqual(
+            parse_junit_xml_files(['files/xml-entities-in-names.xml']),
+            ParsedUnitTestResults(
+                files=1,
+                errors=[],
+                suites=1,
+                suite_tests=4,
+                suite_skipped=0,
+                suite_failures=0,
+                suite_errors=0,
+                suite_time=0,
+                cases=[
+                    UnitTestCase(result_file='files/xml-entities-in-names.xml', test_file=None, line=None, class_name=None, test_name='Test with "quotes" in the test name', result='success', message=None, content=None, time=0.0),
+                    UnitTestCase(result_file='files/xml-entities-in-names.xml', test_file=None, line=None, class_name=None, test_name="Test with 'apostrophe' in the test name", result='success', message=None, content=None, time=0.0),
+                    UnitTestCase(result_file='files/xml-entities-in-names.xml', test_file=None, line=None, class_name=None, test_name='Test with & in the test name', result='success', message=None, content=None, time=0.0),
+                    UnitTestCase(result_file='files/xml-entities-in-names.xml', test_file=None, line=None, class_name=None, test_name='Test with < and > in the test name', result='success', message=None, content=None, time=0.0)
+                ]
+            ))
+
     def test_get_results(self):
         success = TestElement('success')
         skipped = TestElement('skipped')

--- a/python/test/test_junit.py
+++ b/python/test/test_junit.py
@@ -16,6 +16,11 @@ class TestElement(Element):
         self._tag = tag
         self.message = message
         self._elem.text = content
+        self._elem.attrib['message'] = message
+
+    @property
+    def text(self):
+        return self._elem.text
 
 
 class TestJunit(unittest.TestCase):

--- a/python/test/test_junit.py
+++ b/python/test/test_junit.py
@@ -506,21 +506,21 @@ class TestJunit(unittest.TestCase):
 
     def test_parse_junit_xml_files_xml_entities_in_test_names(self):
         self.assertEqual(
-            parse_junit_xml_files(['files/xml-entities-in-names.xml']),
+            parse_junit_xml_files(['files/with-xml-entities.xml']),
             ParsedUnitTestResults(
                 files=1,
                 errors=[],
                 suites=1,
                 suite_tests=4,
-                suite_skipped=0,
-                suite_failures=0,
-                suite_errors=0,
+                suite_skipped=2,
+                suite_failures=1,
+                suite_errors=1,
                 suite_time=0,
                 cases=[
-                    UnitTestCase(result_file='files/xml-entities-in-names.xml', test_file=None, line=None, class_name=None, test_name='Test with "quotes" in the test name', result='success', message=None, content=None, time=0.0),
-                    UnitTestCase(result_file='files/xml-entities-in-names.xml', test_file=None, line=None, class_name=None, test_name="Test with 'apostrophe' in the test name", result='success', message=None, content=None, time=0.0),
-                    UnitTestCase(result_file='files/xml-entities-in-names.xml', test_file=None, line=None, class_name=None, test_name='Test with & in the test name', result='success', message=None, content=None, time=0.0),
-                    UnitTestCase(result_file='files/xml-entities-in-names.xml', test_file=None, line=None, class_name=None, test_name='Test with < and > in the test name', result='success', message=None, content=None, time=0.0)
+                    UnitTestCase(result_file='files/with-xml-entities.xml', test_file=None, line=None, class_name=None, test_name='Test with "quotes" in the test name', result='skipped', message='A message with "quotes"', content='Content with "quotes"', time=0.0),
+                    UnitTestCase(result_file='files/with-xml-entities.xml', test_file=None, line=None, class_name=None, test_name="Test with 'apostrophe' in the test name", result='failure', message='A message with \'apostrophes\'', content='Content with \'apostrophes\'', time=0.0),
+                    UnitTestCase(result_file='files/with-xml-entities.xml', test_file=None, line=None, class_name=None, test_name='Test with & in the test name', result='error', message='A message with &', content='Content with &', time=0.0),
+                    UnitTestCase(result_file='files/with-xml-entities.xml', test_file=None, line=None, class_name=None, test_name='Test with < and > in the test name', result='skipped', message='A message with < and >', content='Content with < and >', time=0.0)
                 ]
             ))
 


### PR DESCRIPTION
The junitparser lib provides access to the JUnit XML files. Some string values are HTML encoded, e.g. `TestCase.name` and `TestCase.classname`.

This change accesses those string values through the element's attributes to get pure, non-escaped text data. Can be reverted once this behaviour is fixed upstream.

See https://github.com/weiwei/junitparser/issues/71. Fixes #184.