### PR TITLE
Treat empty input strings as None

### DIFF
--- a/python/publish_unit_test_results.py
+++ b/python/publish_unit_test_results.py
@@ -162,7 +162,8 @@ def get_var(name: str, options: dict) -> Optional[str]:
     Returns the value from the given dict with key 'INPUT_$key',
     or if this does not exist, key 'key'.
     """
-    return options.get(f'INPUT_{name}') or options.get(name)
+    # the last 'or None' turns empty strings into None
+    return options.get(f'INPUT_{name}') or options.get(name) or None
 
 
 def check_var(var: Union[str, List[str]],

--- a/python/test/test_action_script.py
+++ b/python/test/test_action_script.py
@@ -11,8 +11,8 @@ from publish import pull_request_build_mode_merge, fail_on_mode_failures, fail_o
     fail_on_mode_nothing, comment_mode_off, comment_mode_create, comment_mode_update
 from publish.github_action import GithubAction
 from publish.unittestresults import ParsedUnitTestResults, ParseError
-from publish_unit_test_results import get_conclusion, get_commit_sha, \
-    get_settings, get_annotations_config, Settings, get_files, throttle_gh_request_raw, is_float
+from publish_unit_test_results import get_conclusion, get_commit_sha, get_var, \
+    get_settings, get_annotations_config, Settings, get_files, throttle_gh_request_raw, is_float, main
 from test import chdir
 
 event = dict(pull_request=dict(head=dict(sha='event_sha')))
@@ -120,6 +120,13 @@ class Test(unittest.TestCase):
             actual = get_commit_sha(event, event_name, options)
             self.assertEqual('event_sha', actual)
 
+    def test_get_var(self):
+        self.assertIsNone(get_var('NAME', dict()))
+        self.assertIsNone(get_var('NAME', dict(name='case sensitive')))
+        self.assertEquals(get_var('NAME', dict(NAME='value')), 'value')
+        self.assertEquals(get_var('NAME', dict(INPUT_NAME='precedence', NAME='value')), 'precedence')
+        self.assertIsNone(get_var('NAME', dict(NAME='')))
+
     @staticmethod
     def get_settings(token='token',
                      api_url='http://github.api.url/',
@@ -177,6 +184,16 @@ class Test(unittest.TestCase):
                    for key, value in options.items()
                    if key not in {'GITHUB_API_URL', 'GITHUB_GRAPHQL_URL', 'GITHUB_SHA'}}
         self.do_test_get_settings(**options)
+
+    def test_get_settings_event_file(self):
+        self.do_test_get_settings(expected=self.get_settings(event_file=None))
+        self.do_test_get_settings(EVENT_FILE='', expected=self.get_settings(event_file=None))
+        self.do_test_get_settings(EVENT_FILE=None, expected=self.get_settings(event_file=None))
+
+        with tempfile.NamedTemporaryFile(mode='wb') as file:
+            file.write(b'{}')
+            file.flush()
+            self.do_test_get_settings(EVENT_FILE=file.name, expected=self.get_settings(event_file=file.name))
 
     def test_get_settings_github_api_url(self):
         self.do_test_get_settings(GITHUB_API_URL='https://api.github.onpremise.com', expected=self.get_settings(api_url='https://api.github.onpremise.com'))
@@ -690,3 +707,32 @@ class Test(unittest.TestCase):
         ]:
             with self.subTest(value=value):
                 self.assertEqual(expected, is_float(value))
+
+    def test_main_fork_pr_check(self):
+        with tempfile.NamedTemporaryFile(mode='wb') as file:
+            file.write(b'{ "pull_request": { "head": { "repo": { "full_name": "fork/repo" } } } }')
+            file.flush()
+
+            gha = mock.MagicMock()
+            settings = get_settings(dict(
+                COMMIT='commit',
+                GITHUB_TOKEN='********',
+                GITHUB_EVENT_PATH=file.name,
+                GITHUB_EVENT_NAME='pull_request',
+                GITHUB_REPOSITORY='repo',
+                EVENT_FILE=None
+            ), gha)
+
+            def do_raise(*args):
+                # if this is raised, the tested main method did not return where expected but continued
+                raise RuntimeError('This is not expected to be called')
+
+            with mock.patch('publish_unit_test_results.get_files') as m:
+                m.side_effect = do_raise
+                main(settings, gha)
+
+            gha.warning.assert_called_once_with('This action is running on a pull_request event for a fork repository. '
+                                                'It cannot do anything useful like creating check runs or pull request '
+                                                'comments. To run the action on fork repository pull requests, see '
+                                                'https://github.com/EnricoMi/publish-unit-test-result-action/blob/v1.20'
+                                                '/README.md#support-fork-repositories-and-dependabot-branches')


### PR DESCRIPTION
Composite action calls into the Docker image and sets all supported inputs. Here, originally unset inputs are set as empty strings:

https://github.com/EnricoMi/publish-unit-test-result-action/blob/fbe06cdc30e0d61a17e2a41d579239cf8e1c6841/composite/action.yml#L115-L138

The `event_file` arguments turns out to be the only effected by this, all other have defaults for `None` and empty strings. This PR turns empty input strings into proper `None`s. This makes the "running-on-a-fork-PR" check in `main` work for the composite action (where `settings.event_file` is not `None` but an empty string):

https://github.com/EnricoMi/publish-unit-test-result-action/blob/fbe06cdc30e0d61a17e2a41d579239cf8e1c6841/python/publish_unit_test_results.py#L63-L71

As @BlasiusSecundus showed in https://github.com/EnricoMi/publish-unit-test-result-action/issues/188#issuecomment-982040155, the composite action fails on a fork PR because it tries to write-access the API, which fails with 403, which is retried. We have to retry all 403 because we cannot distinguish between 403 responses that are retry-able due to rate-limit (#150, #170) and those that are not retry-able because we are running in a fork repository context (#167). The "running-on-a-fork-PR" check is supposed to avoid the latter case.