### PR TITLE
Make reset timestamps UTC, test with specific timezone

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -81,6 +81,14 @@ jobs:
           cd python/test
           python -m pytest --capture=tee-sys --continue-on-collection-errors --junit-xml ../../test-results/pytest.xml
 
+      - name: PyTest (EST)
+        env:
+          TZ: US/Eastern
+          PYTHONPATH: ..
+        run: |
+          cd python/test
+          python -m pytest --capture=tee-sys --continue-on-collection-errors --junit-xml ../../test-results/pytest-est.xml
+
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -89,6 +89,14 @@ jobs:
           cd python/test
           python -m pytest --capture=tee-sys --continue-on-collection-errors --junit-xml ../../test-results/pytest-est.xml
 
+      - name: PyTest (AEST)
+        env:
+          TZ: Australia/Canberra
+          PYTHONPATH: ..
+        run: |
+          cd python/test
+          python -m pytest --capture=tee-sys --continue-on-collection-errors --junit-xml ../../test-results/pytest-aest.xml
+
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v2

--- a/python/publish/retry.py
+++ b/python/publish/retry.py
@@ -73,13 +73,14 @@ class GitHubRetry(Retry):
                             if 'X-RateLimit-Reset' in response.headers:
                                 value = response.headers.get('X-RateLimit-Reset')
                                 if value and value.isdigit():
-                                    reset = datetime.datetime.fromtimestamp(int(value))
+                                    reset = datetime.datetime.utcfromtimestamp(int(value))
                                     delta = reset - self._utc_now()
                                     retry = super().increment(method, url, response, error, _pool, _stacktrace)
                                     backoff = retry.get_backoff_time()
 
                                     if delta.total_seconds() > 0:
-                                        logger.info(f'Reset occurs in {str(delta)} ({reset}), setting next backoff to {delta.total_seconds()}s')
+                                        logger.info(f'Reset occurs in {str(delta)} ({value} / {reset}), '
+                                                    f'setting next backoff to {delta.total_seconds()}s')
 
                                         def get_backoff_time():
                                             # plus 1s as it is not clear when in that second the reset occurs

--- a/python/test/test_github.py
+++ b/python/test/test_github.py
@@ -141,7 +141,7 @@ class TestGitHub(unittest.TestCase):
                              repo_response=Response(response=f'{{"message": "{message}"}}', status=403, headers={'X-RateLimit-Reset': '1644768030'})):
             self.gha.reset_mock()
 
-            with mock.patch('publish.retry.GitHubRetry._utc_now', return_value=datetime.datetime.fromtimestamp(1644768000)), \
+            with mock.patch('publish.retry.GitHubRetry._utc_now', return_value=datetime.datetime.utcfromtimestamp(1644768000)), \
                  mock.patch('time.sleep') as sleep:
                     with self.assertRaises(requests.exceptions.RetryError) as context:
                         self.gh.get_repo('owner/repo')


### PR DESCRIPTION
Fixes #225.

Reproduced in https://github.com/EnricoMi/python/runs/5324173294?check_suite_focus=true#step:5:179:

```
  2022-02-25 06:01:15 +1030 - publish-unit-test-results -  INFO - There is no Retry-After given in the response header
  2022-02-25 06:01:15 +1030 - publish-unit-test-results -  INFO - Response body indicates retry-able error: api rate limit exceeded for installation id 5425010.
  2022-02-25 06:01:15 +1030 - publish-unit-test-results - DEBUG - Response header contains X-RateLimit-Limit=30
  2022-02-25 06:01:15 +1030 - publish-unit-test-results - DEBUG - Response header contains X-RateLimit-Remaining=0
  2022-02-25 06:01:15 +1030 - publish-unit-test-results - DEBUG - Response header contains X-RateLimit-Reset=1645731119
  2022-02-25 06:01:15 +1030 - publish-unit-test-results - DEBUG - Response header contains X-RateLimit-Used=30
  2022-02-25 06:01:15 +1030 - publish-unit-test-results - DEBUG - Response header contains X-RateLimit-Resource=search
  2022-02-25 06:01:15 +1030 - publish-unit-test-results -  INFO - Reset occurs in 10:30:43.026608 (2022-02-25 06:01:59), setting next backoff to 37843.026608s
```

Fixed in https://github.com/EnricoMi/python/runs/5324190458?check_suite_focus=true#step:5:173:
```
  2022-02-25 06:02:45 +1030 - publish-unit-test-results -  INFO - There is no Retry-After given in the response header
  2022-02-25 06:02:45 +1030 - publish-unit-test-results -  INFO - Response body indicates retry-able error: api rate limit exceeded for installation id 5425010.
  2022-02-25 06:02:45 +1030 - publish-unit-test-results - DEBUG - Response header contains X-RateLimit-Limit=30
  2022-02-25 06:02:45 +1030 - publish-unit-test-results - DEBUG - Response header contains X-RateLimit-Remaining=0
  2022-02-25 06:02:45 +1030 - publish-unit-test-results - DEBUG - Response header contains X-RateLimit-Reset=1645731180
  2022-02-25 06:02:45 +1030 - publish-unit-test-results - DEBUG - Response header contains X-RateLimit-Used=30
  2022-02-25 06:02:45 +1030 - publish-unit-test-results - DEBUG - Response header contains X-RateLimit-Resource=search
  2022-02-25 06:02:45 +1030 - publish-unit-test-results -  INFO - Reset occurs in 0:00:14.222318 (1645731180 / 2022-02-24 19:33:00), setting next backoff to 14.222318s
```