### PR TITLE
Testsuites without testcases

### DIFF
--- a/python/publish/unittestresults.py
+++ b/python/publish/unittestresults.py
@@ -268,6 +268,21 @@ def get_test_results(parsed_results: ParsedUnitTestResultsWithCommit,
     :return: unit test result statistics
     """
     cases = parsed_results.cases
+    if len(cases) == 0:
+        return parsed_results.with_stats(
+            # test states and counts from cases
+            cases_skipped=parsed_results.suite_skipped,
+            cases_failures=parsed_results.suite_failures,
+            cases_errors=parsed_results.suite_errors,
+            cases_time=parsed_results.suite_time,
+            case_results=UnitTestCaseResults(),
+
+            tests=parsed_results.suite_tests,
+            tests_skipped=parsed_results.suite_skipped,
+            tests_failures=parsed_results.suite_failures,
+            tests_errors=parsed_results.suite_errors,
+        )
+
     cases_skipped = [case for case in cases if case.result in ['skipped', 'disabled']]
     cases_failures = [case for case in cases if case.result == 'failure']
     cases_errors = [case for case in cases if case.result == 'error']

--- a/python/test/files/no-cases-but-tests.xml
+++ b/python/test/files/no-cases-but-tests.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite errors="0" failures="1" hostname="test" name="pytest" skipped="2" tests="6" time="0.010" timestamp="2020-09-01T07:11:23.815873"></testsuite></testsuites>

--- a/python/test/test_publish.py
+++ b/python/test/test_publish.py
@@ -1868,6 +1868,16 @@ class PublishTest(unittest.TestCase):
                               f'\n'
                               f'Results for commit a commit.\n'))
 
+    def test_file_without_cases_but_with_tests(self):
+        parsed = parse_junit_xml_files(['files/no-cases-but-tests.xml']).with_commit('a commit sha')
+        results = get_test_results(parsed, False)
+        stats = get_stats(results)
+        md = get_long_summary_md(stats)
+        self.assertEqual(md, (f'1 files  1 suites   0s {duration_label_md}\n'
+                              f'6 {all_tests_label_md} 3 {passed_tests_label_md} 2 {skipped_tests_label_md} 1 {failed_tests_label_md}\n'
+                              f'\n'
+                              f'Results for commit a commit.\n'))
+
     def test_non_parsable_file(self):
         parsed = parse_junit_xml_files(['files/empty.xml']).with_commit('a commit sha')
         results = get_test_results(parsed, False)


### PR DESCRIPTION
XML files without `<testcase>` tags still contain the number of tests, skipped tests and failures in the `<testsuites>` tags. The action then reports those numbers as "runs" while tests are all 0 (first seen in #231):

![grafik](https://user-images.githubusercontent.com/44700269/156947087-902a231c-f2b5-42b6-a3a8-8ca221fccd01.png)

This fixes this. The "tests" line contains the numbers and the "run" line is removed, as there are no individual test case information.