### PR TITLE
Fix python interpreter detection

### DIFF
--- a/composite/action.yml
+++ b/composite/action.yml
@@ -105,8 +105,7 @@ runs:
           fi
 
           interpreter="$(which python)"
-          interpreter3="${interpreter}3"
-          if [[ ! -e "$interpreter3" ]]
+          if [[ ! -e "${interpreter}3" ]]
           then
             mkdir -p "$RUNNER_TEMP/bin/"
             ln -s "$interpreter" "$RUNNER_TEMP/bin/python3"

--- a/composite/action.yml
+++ b/composite/action.yml
@@ -95,7 +95,7 @@ runs:
         echo '##[group]Check for Python3'
         if ! which python3
         then
-          if ! which python || [[ $(python -V) != *"python 3."* ]]
+          if ! which python || [[ $(python -V) != *"python 3."* && $(python -V) != *"Python 3."* ]]
           then
             echo "::error::No python3 interpreter found. Please setup python before running this action. You could use https://github.com/actions/setup-python."
             exit 1

--- a/composite/action.yml
+++ b/composite/action.yml
@@ -109,8 +109,8 @@ runs:
           if [[ ! -e "$interpreter3" ]]
           then
             mkdir -p "$RUNNER_TEMP/bin/"
-            ln -s "$interpreter" "$RUNNER_TEMP/bin/${interpreter}3"
-            echo "PATH=$PATH:$RUNNER_TEMP/bin/${interpreter}3" >> $GITHUB_ENV
+            ln -s "$interpreter" "$RUNNER_TEMP/bin/python3"
+            echo "$RUNNER_TEMP/bin" >> $GITHUB_PATH
           fi
         fi
         echo '##[endgroup]'

--- a/composite/action.yml
+++ b/composite/action.yml
@@ -108,7 +108,7 @@ runs:
           interpreter3="${interpreter}3"
           if [[ ! -e "$interpreter3" ]]
           then
-            ln -s $interpreter3 $interpreter
+            ln -s $interpreter $interpreter3
           fi
         fi
         echo '##[endgroup]'

--- a/composite/action.yml
+++ b/composite/action.yml
@@ -93,7 +93,10 @@ runs:
     - name: Check for Python3
       run: |
         echo '##[group]Check for Python3'
-        if ! which python3
+        # we check version here just to execute `python3` with an argument
+        # on Windows, there is a `python3.exe` that is a proxy to trigger installation from app store
+        # command `which python3` finds that, but `python3 -V` does not return the version on stdout
+        if ! which python3 || [[ $(python3 -V) != *"python 3."* && $(python3 -V) != *"Python 3."* ]]
         then
           if ! which python || [[ $(python -V) != *"python 3."* && $(python -V) != *"Python 3."* ]]
           then

--- a/composite/action.yml
+++ b/composite/action.yml
@@ -108,7 +108,9 @@ runs:
           interpreter3="${interpreter}3"
           if [[ ! -e "$interpreter3" ]]
           then
-            ln -s $interpreter $interpreter3
+            mkdir -p "$RUNNER_TEMP/bin/"
+            ln -s "$interpreter" "$RUNNER_TEMP/bin/${interpreter}3"
+            echo "PATH=$PATH:$RUNNER_TEMP/bin/${interpreter}3" >> $GITHUB_ENV
           fi
         fi
         echo '##[endgroup]'


### PR DESCRIPTION
Currently the composite action does not work on self-hosted Windows runners because the version check does not pass.
The version string is printed with an upper case P, at least for python 3.9. Not sure about older versions so I adjusted the check to work with both.
```shell
$ python -V
Python 3.9.12
```
