### PR TITLE
Rename files arg to junit_files, deprecate files

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -147,7 +147,7 @@ jobs:
         uses: ./
         with:
           check_name: Test Results (Dockerfile)
-          files: "artifacts/**/*.xml"
+          junit_files: "artifacts/**/*.xml"
           json_file: "tests.json"
           log_level: DEBUG
 
@@ -199,11 +199,11 @@ jobs:
         id: test-results
         if: always()
         run: |
-          docker run --workdir $GITHUB_WORKSPACE --rm -e INPUT_CHECK_NAME -e INPUT_FILES -e INPUT_TIME_UNIT -e INPUT_GITHUB_TOKEN -e INPUT_GITHUB_RETRIES -e INPUT_COMMIT -e INPUT_COMMENT_TITLE -e INPUT_FAIL_ON -e INPUT_REPORT_INDIVIDUAL_RUNS -e INPUT_DEDUPLICATE_CLASSES_BY_FILE_NAME -e INPUT_IGNORE_RUNS -e INPUT_HIDE_COMMENTS -e INPUT_COMMENT_ON_PR -e INPUT_COMMENT_MODE -e INPUT_COMPARE_TO_EARLIER_COMMIT -e INPUT_PULL_REQUEST_BUILD -e INPUT_EVENT_FILE -e INPUT_EVENT_NAME -e INPUT_TEST_CHANGES_LIMIT -e INPUT_CHECK_RUN_ANNOTATIONS -e INPUT_CHECK_RUN_ANNOTATIONS_BRANCH -e INPUT_SECONDS_BETWEEN_GITHUB_READS -e INPUT_SECONDS_BETWEEN_GITHUB_WRITES -e INPUT_JSON_FILE -e INPUT_JOB_SUMMARY -e HOME -e GITHUB_JOB -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RETENTION_DAYS -e GITHUB_ACTOR -e GITHUB_WORKFLOW -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GITHUB_EVENT_NAME -e GITHUB_SERVER_URL -e GITHUB_API_URL -e GITHUB_GRAPHQL_URL -e GITHUB_WORKSPACE -e GITHUB_ACTION -e GITHUB_EVENT_PATH -e GITHUB_ACTION_REPOSITORY -e GITHUB_ACTION_REF -e GITHUB_PATH -e GITHUB_ENV -e GITHUB_STEP_SUMMARY -e RUNNER_OS -e RUNNER_TOOL_CACHE -e RUNNER_TEMP -e RUNNER_WORKSPACE -e ACTIONS_RUNTIME_URL -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "$RUNNER_TEMP":"$RUNNER_TEMP" -v "$GITHUB_WORKSPACE":"$GITHUB_WORKSPACE" enricomi/publish-unit-test-result-action:latest
+          docker run --workdir $GITHUB_WORKSPACE --rm -e INPUT_CHECK_NAME -e INPUT_JUNIT_FILES -e INPUT_TIME_UNIT -e INPUT_GITHUB_TOKEN -e INPUT_GITHUB_RETRIES -e INPUT_COMMIT -e INPUT_COMMENT_TITLE -e INPUT_FAIL_ON -e INPUT_REPORT_INDIVIDUAL_RUNS -e INPUT_DEDUPLICATE_CLASSES_BY_FILE_NAME -e INPUT_IGNORE_RUNS -e INPUT_HIDE_COMMENTS -e INPUT_COMMENT_ON_PR -e INPUT_COMMENT_MODE -e INPUT_COMPARE_TO_EARLIER_COMMIT -e INPUT_PULL_REQUEST_BUILD -e INPUT_EVENT_FILE -e INPUT_EVENT_NAME -e INPUT_TEST_CHANGES_LIMIT -e INPUT_CHECK_RUN_ANNOTATIONS -e INPUT_CHECK_RUN_ANNOTATIONS_BRANCH -e INPUT_SECONDS_BETWEEN_GITHUB_READS -e INPUT_SECONDS_BETWEEN_GITHUB_WRITES -e INPUT_JSON_FILE -e INPUT_JOB_SUMMARY -e HOME -e GITHUB_JOB -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RETENTION_DAYS -e GITHUB_ACTOR -e GITHUB_WORKFLOW -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GITHUB_EVENT_NAME -e GITHUB_SERVER_URL -e GITHUB_API_URL -e GITHUB_GRAPHQL_URL -e GITHUB_WORKSPACE -e GITHUB_ACTION -e GITHUB_EVENT_PATH -e GITHUB_ACTION_REPOSITORY -e GITHUB_ACTION_REF -e GITHUB_PATH -e GITHUB_ENV -e GITHUB_STEP_SUMMARY -e RUNNER_OS -e RUNNER_TOOL_CACHE -e RUNNER_TEMP -e RUNNER_WORKSPACE -e ACTIONS_RUNTIME_URL -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "$RUNNER_TEMP":"$RUNNER_TEMP" -v "$GITHUB_WORKSPACE":"$GITHUB_WORKSPACE" enricomi/publish-unit-test-result-action:latest
         env:
           INPUT_GITHUB_TOKEN: ${{ github.token }}
           INPUT_CHECK_NAME: Test Results (Docker Image)
-          INPUT_FILES: "artifacts/**/*.xml"
+          INPUT_JUNIT_FILES: "artifacts/**/*.xml"
           INPUT_JSON_FILE: "tests.json"
 
       - name: JSON output
@@ -328,7 +328,7 @@ jobs:
         uses: ./composite
         with:
           check_name: Test Results (${{ matrix.os-label }} python ${{ matrix.python }})
-          files: "artifacts${{ steps.os.outputs.path-sep }}**${{ steps.os.outputs.path-sep }}*.xml"
+          junit_files: "artifacts${{ steps.os.outputs.path-sep }}**${{ steps.os.outputs.path-sep }}*.xml"
           json_file: "tests.json"
 
       - name: JSON output
@@ -379,7 +379,7 @@ jobs:
         with:
           check_name: Test Results (setup-python)
           comment_mode: create new
-          files: "artifacts/**/*.xml"
+          junit_files: "artifacts/**/*.xml"
           json_file: "tests.json"
 
       - name: JSON output
@@ -421,7 +421,7 @@ jobs:
         with:
           check_name: Test Results (Test Files)
           fail_on: nothing
-          files: "test-files/**.xml"
+          junit_files: "test-files/**.xml"
           json_file: "tests.json"
           log_level: DEBUG
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can add this action to your GitHub workflow for ![Ubuntu Linux](https://badg
   uses: EnricoMi/publish-unit-test-result-action@v1
   if: always()
   with:
-    files: "test-results/**/*.xml"
+    junit_files: "test-results/**/*.xml"
 ```
 
 Use this for ![macOS](https://badgen.net/badge/icon/macOS?icon=apple&label) (e.g. `runs-on: macos-latest`)
@@ -33,7 +33,7 @@ and ![Windows](https://badgen.net/badge/icon/Windows?icon=windows&label) (e.g. `
   uses: EnricoMi/publish-unit-test-result-action/composite@v1
   if: always()
   with:
-    files: "test-results/**/*.xml"
+    junit_files: "test-results/**/*.xml"
 ```
 
 See the [notes on running this action as a composite action](#running-as-a-composite-action) if you run it on Windows or macOS.
@@ -160,7 +160,7 @@ There have to be at least one pattern starting without a `!`:
 
 ```yaml
 with:
-  files: |
+  junit_files: |
     *.xml
     !config.xml
 ```
@@ -212,7 +212,7 @@ through the expression `steps.<id>.outputs.json`.
   id: test-results
   if: always()
   with:
-    files: "test-results/**/*.xml"
+    junit_files: "test-results/**/*.xml"
 
 - name: Conclusion
   run: echo "Conclusion is ${{ fromJSON( steps.test-results.outputs.json ).conclusion }}"
@@ -358,7 +358,7 @@ jobs:
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1
         with:
-          files: "artifacts/**/*.xml"
+          junit_files: "artifacts/**/*.xml"
 ```
 
 ## Support fork repositories and dependabot branches
@@ -471,7 +471,7 @@ jobs:
           commit: ${{ github.event.workflow_run.head_sha }}
           event_file: artifacts/Event File/event.json
           event_name: ${{ github.event.workflow_run.event }}
-          files: "artifacts/**/*.xml"
+          junit_files: "artifacts/**/*.xml"
 ```
 
 Note: Running this action on `pull_request_target` events is [dangerous if combined with code checkout and code execution](https://securitylab.github.com/research/github-actions-preventing-pwn-requests).
@@ -489,7 +489,7 @@ steps:
   id: test-results
   if: always()
   with:
-    files: "test-results/**/*.xml"
+    junit_files: "test-results/**/*.xml"
 
 - name: Set badge color
   shell: bash
@@ -593,7 +593,7 @@ publish-test-results:
     - name: Publish Test Results
       uses: EnricoMi/publish-unit-test-result-action/composite@v1
       with:
-        files: "artifacts/**/*.xml"
+        junit_files: "artifacts/**/*.xml"
 ```
 
 ### Slow startup of composite action

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ See the complete list of options below.
 
 |Option|Default Value|Description|
 |:-----|:-----:|:----------|
-|`files`|`*.xml`|File patterns to select the test result XML files, e.g. `"test-results/**/*.xml"`. Use multiline string for multiple patterns. Supports `*`, `**`, `?`, `[]`. Excludes files when starting with `!`. |
+|`junit_files`|`*.xml`|File patterns of JUnit XML test result files. Supports `*`, `**`, `?`, and `[]`. Use multiline string for multiple patterns. Patterns starting with `!` exclude the matching files. There have to be at least one pattern starting without a `!`.|
 |`time_unit`|`seconds`|Time values in the XML files have this unit. Supports `seconds` and `milliseconds`.|
 |`check_name`|`"Unit Test Results"`|An alternative name for the check result.|
 |`comment_title`|same as `check_name`|An alternative name for the pull request comment.|

--- a/action.yml
+++ b/action.yml
@@ -25,9 +25,9 @@ inputs:
     description: 'The created test result check run has failure state if any test fails or test errors occur. Never fails when set to "nothing", fails only on errors when set to "errors". Default is "test failures".'
     default: 'test failures'
     required: false
-  files:
-    description: 'File patterns of test result files. Supports *, **, ?, and []. Use multiline string for multiple patterns.'
-    required: true
+  junit_files:
+    description: 'File patterns of JUnit XML test result files. Supports *, **, ?, and []. Use multiline string for multiple patterns. Patterns starting with `!` exclude the matching files. There have to be at least one pattern starting without a `!`.'
+    required: false
   time_unit:
     description: 'Time values in the XML files have this unit. Supports "seconds" and "milliseconds".'
     default: 'seconds'

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
     default: 'test failures'
     required: false
   junit_files:
-    description: 'File patterns of JUnit XML test result files. Supports *, **, ?, and []. Use multiline string for multiple patterns. Patterns starting with `!` exclude the matching files. There have to be at least one pattern starting without a `!`.'
+    description: 'File patterns of JUnit XML test result files. Supports *, **, ?, and []. Use multiline string for multiple patterns. Patterns starting with ! exclude the matching files. There have to be at least one pattern starting without a `!`.'
     required: false
   time_unit:
     description: 'Time values in the XML files have this unit. Supports "seconds" and "milliseconds".'
@@ -54,11 +54,11 @@ inputs:
     default: 'update last'
     required: false
   job_summary:
-    description: 'Set to `true`, the results are published as part of the job summary page of the workflow run'
+    description: 'Set to "true", the results are published as part of the job summary page of the workflow run'
     required: false
     default: 'true'
   compare_to_earlier_commit:
-    description: 'Test results are compared to results of earlier commits to highlight changes: false - disable comparison, true - compare across commits'
+    description: 'Test results are compared to results of earlier commits to highlight changes: "false" - disable comparison, "true" - compare across commits'
     default: 'true'
     required: false
   pull_request_build:

--- a/composite/action.yml
+++ b/composite/action.yml
@@ -146,6 +146,7 @@ runs:
         CHECK_NAME: ${{ inputs.check_name }}
         COMMENT_TITLE: ${{ inputs.comment_title }}
         FAIL_ON: ${{ inputs.fail_on }}
+        # deprecated
         FILES: ${{ inputs.files }}
         JUNIT_FILES: ${{ inputs.junit_files }}
         TIME_UNIT: ${{ inputs.time_unit }}
@@ -166,7 +167,9 @@ runs:
         SECONDS_BETWEEN_GITHUB_WRITES: ${{ inputs.seconds_between_github_writes }}
         JSON_FILE: ${{ inputs.json_file }}
         JOB_SUMMARY: ${{ inputs.job_summary }}
+        # not documented
         ROOT_LOG_LEVEL: ${{ inputs.root_log_level }}
+        # not documented
         LOG_LEVEL: ${{ inputs.log_level }}
       shell: bash
 

--- a/composite/action.yml
+++ b/composite/action.yml
@@ -25,9 +25,9 @@ inputs:
     description: 'The created test result check run has failure state if any test fails or test errors occur. Never fails when set to "nothing", fails only on errors when set to "errors". Default is "test failures".'
     required: false
     default: 'test failures'
-  files:
-    description: 'File patterns of test result files. Supports *, **, ?, and []. Use multiline string for multiple patterns.'
-    required: true
+  junit_files:
+    description: 'File patterns of JUnit XML test result files. Supports *, **, ?, and []. Use multiline string for multiple patterns. Patterns starting with `!` exclude the matching files. There have to be at least one pattern starting without a `!`.'
+    required: false
   time_unit:
     description: 'Time values in the XML files have this unit. Supports "seconds" and "milliseconds".'
     default: 'seconds'
@@ -147,6 +147,7 @@ runs:
         COMMENT_TITLE: ${{ inputs.comment_title }}
         FAIL_ON: ${{ inputs.fail_on }}
         FILES: ${{ inputs.files }}
+        JUNIT_FILES: ${{ inputs.junit_files }}
         TIME_UNIT: ${{ inputs.time_unit }}
         REPORT_INDIVIDUAL_RUNS: ${{ inputs.report_individual_runs }}
         DEDUPLICATE_CLASSES_BY_FILE_NAME: ${{ inputs.deduplicate_classes_by_file_name }}

--- a/composite/action.yml
+++ b/composite/action.yml
@@ -26,7 +26,7 @@ inputs:
     required: false
     default: 'test failures'
   junit_files:
-    description: 'File patterns of JUnit XML test result files. Supports *, **, ?, and []. Use multiline string for multiple patterns. Patterns starting with `!` exclude the matching files. There have to be at least one pattern starting without a `!`.'
+    description: 'File patterns of JUnit XML test result files. Supports *, **, ?, and []. Use multiline string for multiple patterns. Patterns starting with ! exclude the matching files. There have to be at least one pattern starting without a `!`.'
     required: false
   time_unit:
     description: 'Time values in the XML files have this unit. Supports "seconds" and "milliseconds".'
@@ -54,11 +54,11 @@ inputs:
     required: false
     default: 'update last'
   job_summary:
-    description: 'Set to `true`, the results are published as part of the job summary page of the workflow run'
+    description: 'Set to "true", the results are published as part of the job summary page of the workflow run'
     required: false
     default: 'true'
   compare_to_earlier_commit:
-    description: 'Test results are compared to results of earlier commits to highlight changes: false - disable comparison, true - compare across commits'
+    description: 'Test results are compared to results of earlier commits to highlight changes: "false" - disable comparison, "true" - compare across commits'
     required: false
     default: 'true'
   pull_request_build:

--- a/python/publish/publisher.py
+++ b/python/publish/publisher.py
@@ -37,7 +37,7 @@ class Settings:
     json_file: Optional[str]
     fail_on_errors: bool
     fail_on_failures: bool
-    files_glob: str
+    junit_files_glob: str
     time_factor: float
     check_name: str
     comment_title: str

--- a/python/publish_unit_test_results.py
+++ b/python/publish_unit_test_results.py
@@ -243,6 +243,9 @@ def get_settings(options: dict, gha: Optional[GithubAction] = None) -> Settings:
     test_changes_limit = get_var('TEST_CHANGES_LIMIT', options) or '10'
     check_var_condition(test_changes_limit.isnumeric(), f'TEST_CHANGES_LIMIT must be a positive integer or 0: {test_changes_limit}')
 
+    if get_var('FILES', options):
+        gha.warning('Option FILES is deprecated, please use JUNIT_FILES instead!')
+
     time_unit = get_var('TIME_UNIT', options) or 'seconds'
     time_factors = {'seconds': 1.0, 'milliseconds': 0.001}
     time_factor = time_factors.get(time_unit.lower())
@@ -280,7 +283,7 @@ def get_settings(options: dict, gha: Optional[GithubAction] = None) -> Settings:
         json_file=get_var('JSON_FILE', options),
         fail_on_errors=fail_on_errors,
         fail_on_failures=fail_on_failures,
-        files_glob=get_var('FILES', options) or '*.xml',
+        junit_files_glob=get_var('JUNIT_FILES', options) or get_var('FILES', options) or '*.xml',
         time_factor=time_factor,
         check_name=check_name,
         comment_title=get_var('COMMENT_TITLE', options) or check_name,

--- a/python/publish_unit_test_results.py
+++ b/python/publish_unit_test_results.py
@@ -70,11 +70,11 @@ def main(settings: Settings, gha: GithubAction) -> None:
         return
 
     # resolve the files_glob to files
-    files = get_files(settings.files_glob)
+    files = get_files(settings.junit_files_glob)
     if len(files) == 0:
-        gha.warning(f'Could not find any files for {settings.files_glob}')
+        gha.warning(f'Could not find any files for {settings.junit_files_glob}')
     else:
-        logger.info(f'reading {settings.files_glob}')
+        logger.info(f'reading {settings.junit_files_glob}')
         logger.debug(f'reading {list(files)}')
 
     # get the unit test results

--- a/python/test/test_action_script.py
+++ b/python/test/test_action_script.py
@@ -141,7 +141,7 @@ class Test(unittest.TestCase):
                      commit='commit',
                      fail_on_errors=True,
                      fail_on_failures=True,
-                     files_glob='files',
+                     junit_files_glob='junit-files',
                      time_factor=1.0,
                      check_name='check name',
                      comment_title='title',
@@ -171,7 +171,7 @@ class Test(unittest.TestCase):
             json_file=json_file,
             fail_on_errors=fail_on_errors,
             fail_on_failures=fail_on_failures,
-            files_glob=files_glob,
+            junit_files_glob=junit_files_glob,
             time_factor=time_factor,
             check_name=check_name,
             comment_title=comment_title,
@@ -233,10 +233,16 @@ class Test(unittest.TestCase):
                     self.do_test_get_settings(GITHUB_RETRIES=retries, expected=None)
                 self.assertIn(f'GITHUB_RETRIES must be a positive integer or 0: {retries}', re.exception.args)
 
-    def test_get_settings_files(self):
-        self.do_test_get_settings(FILES='file', expected=self.get_settings(files_glob='file'))
-        self.do_test_get_settings(FILES='file\nfile2', expected=self.get_settings(files_glob='file\nfile2'))
-        self.do_test_get_settings(FILES=None, expected=self.get_settings(files_glob='*.xml'))
+    def test_get_settings_junit_files(self):
+        self.do_test_get_settings(JUNIT_FILES='file', expected=self.get_settings(junit_files_glob='file'))
+        self.do_test_get_settings(JUNIT_FILES='file\nfile2', expected=self.get_settings(junit_files_glob='file\nfile2'))
+        self.do_test_get_settings(JUNIT_FILES=None, expected=self.get_settings(junit_files_glob='*.xml'))
+
+        # this is the deprecated version of JUNIT_FILES
+        self.do_test_get_settings(JUNIT_FILES='junit-file', FILES='file', expected=self.get_settings(junit_files_glob='junit-file'), warning='Option FILES is deprecated, please use JUNIT_FILES instead!')
+        self.do_test_get_settings(JUNIT_FILES=None, FILES='file', expected=self.get_settings(junit_files_glob='file'), warning='Option FILES is deprecated, please use JUNIT_FILES instead!')
+        self.do_test_get_settings(JUNIT_FILES=None, FILES='file\nfile2', expected=self.get_settings(junit_files_glob='file\nfile2'), warning='Option FILES is deprecated, please use JUNIT_FILES instead!')
+        self.do_test_get_settings(JUNIT_FILES=None, FILES=None, expected=self.get_settings(junit_files_glob='*.xml'))
 
     def test_get_settings_time_unit(self):
         self.do_test_get_settings(TIME_UNIT=None, expected=self.get_settings(time_factor=1.0))
@@ -452,7 +458,7 @@ class Test(unittest.TestCase):
                 GITHUB_TOKEN='token',
                 GITHUB_REPOSITORY='repo',
                 COMMIT='commit',  # defaults to get_commit_sha(event, event_name)
-                FILES='files',
+                JUNIT_FILES='junit-files',
                 COMMENT_TITLE='title',  # defaults to check name
                 COMMENT_MODE='create new',  # true unless 'false'
                 JOB_SUMMARY='true',

--- a/python/test/test_action_yml.py
+++ b/python/test/test_action_yml.py
@@ -33,7 +33,7 @@ class TestActionYml(unittest.TestCase):
             action = yaml.safe_load(r)
 
         # these are not documented in the action.yml files but still needs to be forwarded
-        extra_inputs = ['root_log_level', 'log_level']
+        extra_inputs = ['files', 'root_log_level', 'log_level']
         expected = {key.upper(): f'${{{{ inputs.{key} }}}}' for key in list(action.get('inputs', {}).keys()) + extra_inputs}
 
         steps = action.get('runs', {}).get('steps', [])

--- a/python/test/test_publisher.py
+++ b/python/test/test_publisher.py
@@ -68,7 +68,7 @@ class TestPublisher(unittest.TestCase):
             json_file=json_file,
             fail_on_errors=True,
             fail_on_failures=True,
-            files_glob='*.xml',
+            junit_files_glob='*.xml',
             time_factor=1.0,
             check_name='Check Name',
             comment_title='Comment Title',


### PR DESCRIPTION
This allows to support multiple test result file formats without the need to detect the format. There are multiple XML variants but usually, only a single is format is used and fully known to the user.