### PR TITLE
Use GHA env file to set output in CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -389,16 +389,16 @@ jobs:
         run: |
           case "$OS" in
             ubuntu*)
-              echo "::set-output name=path-sep::/"
-              echo "::set-output name=pip-cache::~/.cache/pip"
+              echo "path-sep=/" >>$GITHUB_OUTPUT
+              echo "pip-cache=~/.cache/pip" >>$GITHUB_OUTPUT
               ;;
             macos*)
-              echo "::set-output name=path-sep::/"
-              echo "::set-output name=pip-cache::~/Library/Caches/pip"
+              echo "path-sep=/" >>$GITHUB_OUTPUT
+              echo "pip-cache=~/Library/Caches/pip" >>$GITHUB_OUTPUT
               ;;
             windows*)
-              echo "::set-output name=path-sep::\\"
-              echo "::set-output name=pip-cache::~\\AppData\\Local\\pip\\Cache"
+              echo "path-sep=\\" >>$GITHUB_OUTPUT
+              echo "pip-cache=~\\AppData\\Local\\pip\\Cache" >>$GITHUB_OUTPUT
               ;;
           esac
         shell: bash
@@ -592,8 +592,8 @@ jobs:
         run: |
           image=$(grep -A 10 "^runs:" action.yml | grep -E "^\s+image:\s" | sed -E -e "s/^\s+image:\s*'//" -e "s/docker:\/\///" -e "s/'\s*$//")
           version=$(cut -d : -f 2 <<< "$image")
-          echo "::set-output name=image::$image"
-          echo "::set-output name=version::$version"
+          echo "image=$image" >>$GITHUB_OUTPUT
+          echo "version=$version" >>$GITHUB_OUTPUT
         shell: bash
 
       - name: Check action image existence
@@ -603,7 +603,7 @@ jobs:
         run: |
           if docker manifest inspect '${{ steps.action.outputs.image }}'
           then
-            echo "::set-output name=exists::true"
+            echo "exists=true" >>$GITHUB_OUTPUT
           fi
         shell: bash
 

--- a/python/test/test_github_action.py
+++ b/python/test/test_github_action.py
@@ -231,7 +231,7 @@ class TestGithubAction(unittest.TestCase):
             gha.add_to_output('var2', 'val4')
 
         # if there is no env file, the output is set via command
-        with gh_action_command_test(self, '::set-output name=varname::varval') as gha:
+        with gh_action_command_test(self, 'varname=varval >>$GITHUB_OUTPUT') as gha:
             gha.add_to_output('varname', 'varval')
 
     def test_add_job_summary(self):

--- a/python/test/test_github_action.py
+++ b/python/test/test_github_action.py
@@ -231,7 +231,7 @@ class TestGithubAction(unittest.TestCase):
             gha.add_to_output('var2', 'val4')
 
         # if there is no env file, the output is set via command
-        with gh_action_command_test(self, 'varname=varval >>$GITHUB_OUTPUT') as gha:
+        with gh_action_command_test(self, '::set-output name=varname::varval') as gha:
             gha.add_to_output('varname', 'varval')
 
     def test_add_job_summary(self):


### PR DESCRIPTION
This should fix the issue with [this](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

[Relevent GH Issue](https://github.com/EnricoMi/publish-unit-test-result-action/issues/363)