### PR TITLE
Fix UnitTestRunResults interface to be compatible with UnitTestRunDeltaResults

### DIFF
--- a/python/publish/publisher.py
+++ b/python/publish/publisher.py
@@ -587,18 +587,18 @@ class Publisher:
 
         if self._settings.comment_mode == comment_mode_changes and \
                 do_changes_require_comment(earlier_stats.is_different if earlier_stats else None,
-                                           stats.has_changes):
+                                           stats.is_delta and stats.has_changes):
             return True
 
         if self._settings.comment_mode == comment_mode_changes_failures and \
                 do_changes_require_comment(earlier_stats.is_different_in_failures if earlier_stats else None,
-                                           stats.has_failure_changes,
+                                           stats.is_delta and stats.has_failure_changes,
                                            'failures'):
             return True
 
         if self._settings.comment_mode in [comment_mode_changes_failures, comment_mode_changes_errors] and \
                 do_changes_require_comment(earlier_stats.is_different_in_errors if earlier_stats else None,
-                                           stats.has_error_changes,
+                                           stats.is_delta and stats.has_error_changes,
                                            'errors'):
             return True
 

--- a/python/test/test_publisher.py
+++ b/python/test/test_publisher.py
@@ -355,15 +355,19 @@ class TestPublisher(unittest.TestCase):
                 ) if not test.earlier_is_none else None
                 current = mock.MagicMock(
                     is_delta=test.current_has_changes is not None,
-                    has_changes=test.current_has_changes,
-                    has_failure_changes=test.current_has_failure_changes,
-                    has_error_changes=test.current_has_error_changes,
                     has_failures=test.current_has_failures,
                     has_errors=test.current_has_errors)
                 if current.is_delta:
+                    current.has_changes = test.current_has_changes
+                    current.has_failure_changes = test.current_has_failure_changes
+                    current.has_error_changes = test.current_has_error_changes
                     current.without_delta = mock.Mock(return_value=current)
                 required = Publisher.require_comment(publisher, current, earlier)
                 self.assertEqual(required, expected)
+                # do not access these prperties when current is not a delta stats
+                self.assertTrue(current.is_delta or 'has_changes' not in current._mock_children, 'has_changes')
+                self.assertTrue(current.is_delta or 'has_failure_changes' not in current._mock_children, 'has_failure_changes')
+                self.assertTrue(current.is_delta or 'has_error_changes' not in current._mock_children, 'has_error_changes')
 
     comment_condition_tests = [CommentConditionTest(earlier_is_none,
                                                     earlier_is_different, earlier_is_different_in_failures, earlier_is_different_in_errors,
@@ -372,14 +376,14 @@ class TestPublisher(unittest.TestCase):
                                                     current_has_failures, current_has_errors)
                                for earlier_is_none in [False, True]
                                for earlier_is_different in [False, True]
-                               for earlier_is_different_in_failures in ([False, True] if not earlier_is_different else [True])
-                               for earlier_is_different_in_errors in ([False, True] if not earlier_is_different else [True])
+                               for earlier_is_different_in_failures in ([False, True] if earlier_is_different else [False])
+                               for earlier_is_different_in_errors in ([False, True] if earlier_is_different else [False])
                                for earlier_has_failures in [False, True]
                                for earlier_has_errors in [False, True]
 
                                for current_has_changes in [None, False, True]
-                               for current_has_failure_changes in ([False, True] if not current_has_changes else [True])
-                               for current_has_error_changes in ([False, True] if not current_has_changes else [True])
+                               for current_has_failure_changes in ([False, True] if current_has_changes else [False])
+                               for current_has_error_changes in ([False, True] if current_has_changes else [False])
                                for current_has_failures in [False, True]
                                for current_has_errors in [False, True]]
 


### PR DESCRIPTION
The Publisher::publish_comment method calls some properties that were not defined on UnitTestRunResults.