### PR TITLE
Add actor name option

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -300,6 +300,7 @@ jobs:
             -e "INPUT_LOG_LEVEL" \
             -e "INPUT_ROOT_LOG_LEVEL" \
             -e "INPUT_GITHUB_TOKEN" \
+            -e "INPUT_GITHUB_ACTOR" \
             -e "INPUT_GITHUB_RETRIES" \
             -e "INPUT_COMMIT" \
             -e "INPUT_COMMENT_TITLE" \

--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ The list of most notable options:
 |:-----|:-----:|:----------|
 |`commit`|`${{env.GITHUB_SHA}}`|An alternative commit SHA to which test results are published. The `push` and `pull_request`events are handled, but for other [workflow events](https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#push) `GITHUB_SHA` may refer to different kinds of commits. See [GitHub Workflow documentation](https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows) for details.|
 |`github_token`|`${{github.token}}`|An alternative GitHub token, other than the default provided by GitHub Actions runner.|
+|`github_actor`|`github-actions`|Used to find older comment to update. Note: this does not change the bot name while commenting. If you use any other GH app, you need provide that app name here. Otherwise all your run will create a new comment.|
 |`github_retries`|`10`|Requests to the GitHub API are retried this number of times. The value must be a positive integer or zero.|
 |`seconds_between_github_reads`|`0.25`|Sets the number of seconds the action waits between concurrent read requests to the GitHub API.|
 |`seconds_between_github_writes`|`2.0`|Sets the number of seconds the action waits between concurrent write requests to the GitHub API.|
@@ -291,7 +292,6 @@ The list of most notable options:
 |`time_unit`|`seconds`|Time values in the XML files have this unit. Supports `seconds` and `milliseconds`.|
 |`job_summary`|`true`| Set to `true`, the results are published as part of the [job summary page](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/) of the workflow run.|
 |`compare_to_earlier_commit`|`true`|Test results are compared to results of earlier commits to show changes:<br/>`false` - disable comparison, `true` - compare across commits.'|
-|`actor_name`|`github-actions`|Used to find older comment to update. Note: this does not change the bot name while commenting. If you use any other GH app, you need provide that app name here. Otherwise all your run will create a new comment.|
 |`test_changes_limit`|`10`|Limits the number of removed or skipped tests reported on pull request comments. This report can be disabled with a value of `0`.|
 |`report_individual_runs`|`false`|Individual runs of the same test may see different failures. Reports all individual failures when set `true`, and the first failure only otherwise.|
 |`report_suite_logs`|`none`|In addition to reporting regular test logs, also report test suite logs. These are logs provided on suite level, not individual test level. Set to `info` for normal output, `error` for error output, `any` for both, or `none` for no suite logs at all. Defaults to `none`.|

--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ The list of most notable options:
 |`time_unit`|`seconds`|Time values in the XML files have this unit. Supports `seconds` and `milliseconds`.|
 |`job_summary`|`true`| Set to `true`, the results are published as part of the [job summary page](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/) of the workflow run.|
 |`compare_to_earlier_commit`|`true`|Test results are compared to results of earlier commits to show changes:<br/>`false` - disable comparison, `true` - compare across commits.'|
+|`actor_name`|`github-actions`|Used to find older comment to update. Note: this does not change the bot name while commenting. If you use any other GH app, you need provide that app name here. Otherwise all your run will create a new comment.|
 |`test_changes_limit`|`10`|Limits the number of removed or skipped tests reported on pull request comments. This report can be disabled with a value of `0`.|
 |`report_individual_runs`|`false`|Individual runs of the same test may see different failures. Reports all individual failures when set `true`, and the first failure only otherwise.|
 |`report_suite_logs`|`none`|In addition to reporting regular test logs, also report test suite logs. These are logs provided on suite level, not individual test level. Set to `info` for normal output, `error` for error output, `any` for both, or `none` for no suite logs at all. Defaults to `none`.|

--- a/action.yml
+++ b/action.yml
@@ -139,7 +139,7 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/enricomi/publish-unit-test-result-action:v2.7.0'
+  image: 'docker://ghcr.io/RafikFarhad/publish-unit-test-result-action:optional-actor-name'
 
 branding:
   icon: 'check-circle'

--- a/action.yml
+++ b/action.yml
@@ -139,7 +139,7 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/RafikFarhad/publish-unit-test-result-action:optional-actor-name'
+  image: 'docker://ghcr.io/rafikfarhad/publish-unit-test-result-action:optional-actor-name'
 
 branding:
   icon: 'check-circle'

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ inputs:
     default: 'false'
     required: false
   actor_name:
-    description: 'The name of the actor that is used for the check run. Defaults: 'github-actions''
+    description: 'The name of the actor that is used for the check run. Defaults: "github-actions"'
     default: 'github-actions'
     required: false
   files:

--- a/action.yml
+++ b/action.yml
@@ -139,7 +139,7 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/rafikfarhad/publish-unit-test-result-action:optional-actor-name'
+  image: 'docker://ghcr.io/enricomi/publish-unit-test-result-action:v2.7.0'
 
 branding:
   icon: 'check-circle'

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,10 @@ inputs:
     description: 'GitHub API Access Token.'
     default: ${{ github.token }}
     required: false
+  github_actor:
+    description: 'The name of the actor that runs this action. Defaults to "github-actions"'
+    default: 'github-actions'
+    required: false
   github_retries:
     description: 'Requests to the GitHub API are retried this number of times. The value must be a positive integer or zero.'
     default: '10'
@@ -36,10 +40,6 @@ inputs:
   action_fail_on_inconclusive:
     description: 'When set "true", the action itself fails when tests are inconclusive (no test results).'
     default: 'false'
-    required: false
-  actor_name:
-    description: 'The name of the actor that is used for the check run. Defaults: "github-actions"'
-    default: 'github-actions'
     required: false
   files:
     description: 'File patterns of test result files. Supports *, **, ?, and []. Use multiline string for multiple patterns. Patterns starting with ! exclude the matching files. There have to be at least one pattern starting without a "!".'

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,10 @@ inputs:
     description: 'When set "true", the action itself fails when tests are inconclusive (no test results).'
     default: 'false'
     required: false
+  actor_name:
+    description: 'The name of the actor that is used for the check run. Defaults: 'github-actions''
+    default: 'github-actions'
+    required: false
   files:
     description: 'File patterns of test result files. Supports *, **, ?, and []. Use multiline string for multiple patterns. Patterns starting with ! exclude the matching files. There have to be at least one pattern starting without a "!".'
     required: false

--- a/composite/action.yml
+++ b/composite/action.yml
@@ -208,6 +208,7 @@ runs:
         echo '##[endgroup]'
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
+        GITHUB_ACTOR: ${{ inputs.github_actor }}
         GITHUB_RETRIES: ${{ inputs.github_retries }}
         COMMIT: ${{ inputs.commit }}
         CHECK_NAME: ${{ inputs.check_name }}

--- a/composite/action.yml
+++ b/composite/action.yml
@@ -7,6 +7,10 @@ inputs:
     description: 'GitHub API Access Token.'
     default: ${{ github.token }}
     required: false
+  github_actor:
+    description: 'The name of the actor that runs this action. Defaults to "github-actions"'
+    default: 'github-actions'
+    required: false
   github_retries:
     description: 'Requests to the GitHub API are retried this number of times. The value must be a positive integer or zero.'
     default: '10'

--- a/python/publish/publisher.py
+++ b/python/publish/publisher.py
@@ -30,6 +30,7 @@ from publish.unittestresults import UnitTestCaseResults, UnitTestRunResults, Uni
 @dataclass(frozen=True)
 class Settings:
     token: str
+    actor: str
     api_url: str
     graphql_url: str
     api_retries: int
@@ -47,7 +48,6 @@ class Settings:
     fail_on_failures: bool
     action_fail: bool
     action_fail_on_inconclusive: bool
-    actor_name: str
     # one of these *files_glob must be set
     files_glob: Optional[str]
     junit_files_glob: Optional[str]
@@ -735,7 +735,7 @@ class Publisher:
 
     def get_action_comments(self, comments: List[Mapping[str, Any]], is_minimized: Optional[bool] = False):
         return list([comment for comment in comments
-                     if comment.get('author', {}).get('login') == self._settings.actor_name
+                     if comment.get('author', {}).get('login') == self._settings.actor
                      and (is_minimized is None or comment.get('isMinimized') == is_minimized)
                      and comment.get('body', '').startswith(f'## {self._settings.comment_title}\n')
                      and ('\nresults for commit ' in comment.get('body') or '\nResults for commit ' in comment.get('body'))])

--- a/python/publish/publisher.py
+++ b/python/publish/publisher.py
@@ -47,6 +47,7 @@ class Settings:
     fail_on_failures: bool
     action_fail: bool
     action_fail_on_inconclusive: bool
+    actor_name: str
     # one of these *files_glob must be set
     files_glob: Optional[str]
     junit_files_glob: Optional[str]
@@ -734,7 +735,7 @@ class Publisher:
 
     def get_action_comments(self, comments: List[Mapping[str, Any]], is_minimized: Optional[bool] = False):
         return list([comment for comment in comments
-                     if comment.get('author', {}).get('login') == 'github-actions'
+                     if comment.get('author', {}).get('login') == self._settings.actor_name
                      and (is_minimized is None or comment.get('isMinimized') == is_minimized)
                      and comment.get('body', '').startswith(f'## {self._settings.comment_title}\n')
                      and ('\nresults for commit ' in comment.get('body') or '\nResults for commit ' in comment.get('body'))])

--- a/python/publish_test_results.py
+++ b/python/publish_test_results.py
@@ -442,7 +442,7 @@ def get_settings(options: dict, gha: GithubAction) -> Settings:
     annotations = get_annotations_config(options, event)
     suite_logs_mode = get_var('REPORT_SUITE_LOGS', options) or default_report_suite_logs
     ignore_runs = get_bool_var('IGNORE_RUNS', options, default=False)
-    actor_name = get_var('ACTOR_NAME', options) or 'github-actions'
+    actor = get_var('GITUHB_ACTOR', options) or 'github-actions'
 
     fail_on = get_var('FAIL_ON', options) or 'test failures'
     check_var(fail_on, 'FAIL_ON', 'Check fail mode', fail_on_modes)
@@ -459,6 +459,7 @@ def get_settings(options: dict, gha: GithubAction) -> Settings:
 
     settings = Settings(
         token=get_var('GITHUB_TOKEN', options),
+        actor=actor,
         api_url=api_url,
         graphql_url=graphql_url,
         api_retries=int(retries),
@@ -476,7 +477,6 @@ def get_settings(options: dict, gha: GithubAction) -> Settings:
         fail_on_failures=fail_on_failures,
         action_fail=get_bool_var('ACTION_FAIL', options, default=False),
         action_fail_on_inconclusive=get_bool_var('ACTION_FAIL_ON_INCONCLUSIVE', options, default=False),
-        actor_name=actor_name,
         files_glob=get_var('FILES', options) or default_files_glob,
         junit_files_glob=get_var('JUNIT_FILES', options),
         nunit_files_glob=get_var('NUNIT_FILES', options),

--- a/python/publish_test_results.py
+++ b/python/publish_test_results.py
@@ -442,7 +442,7 @@ def get_settings(options: dict, gha: GithubAction) -> Settings:
     annotations = get_annotations_config(options, event)
     suite_logs_mode = get_var('REPORT_SUITE_LOGS', options) or default_report_suite_logs
     ignore_runs = get_bool_var('IGNORE_RUNS', options, default=False)
-    actor = get_var('GITUHB_ACTOR', options) or 'github-actions'
+    actor = get_var('GITHUB_ACTOR', options) or 'github-actions'
 
     fail_on = get_var('FAIL_ON', options) or 'test failures'
     check_var(fail_on, 'FAIL_ON', 'Check fail mode', fail_on_modes)

--- a/python/publish_test_results.py
+++ b/python/publish_test_results.py
@@ -442,6 +442,7 @@ def get_settings(options: dict, gha: GithubAction) -> Settings:
     annotations = get_annotations_config(options, event)
     suite_logs_mode = get_var('REPORT_SUITE_LOGS', options) or default_report_suite_logs
     ignore_runs = get_bool_var('IGNORE_RUNS', options, default=False)
+    actor_name = get_var('ACTOR_NAME', options) or 'github-actions'
 
     fail_on = get_var('FAIL_ON', options) or 'test failures'
     check_var(fail_on, 'FAIL_ON', 'Check fail mode', fail_on_modes)
@@ -475,6 +476,7 @@ def get_settings(options: dict, gha: GithubAction) -> Settings:
         fail_on_failures=fail_on_failures,
         action_fail=get_bool_var('ACTION_FAIL', options, default=False),
         action_fail_on_inconclusive=get_bool_var('ACTION_FAIL_ON_INCONCLUSIVE', options, default=False),
+        actor_name=actor_name,
         files_glob=get_var('FILES', options) or default_files_glob,
         junit_files_glob=get_var('JUNIT_FILES', options),
         nunit_files_glob=get_var('NUNIT_FILES', options),

--- a/python/test/test_action_script.py
+++ b/python/test/test_action_script.py
@@ -160,6 +160,7 @@ class Test(unittest.TestCase):
 
     @staticmethod
     def get_settings(token='token',
+                     actor='actor',
                      api_url='http://github.api.url/',
                      graphql_url='http://github.graphql.url/',
                      retries=2,
@@ -202,6 +203,7 @@ class Test(unittest.TestCase):
                      search_pull_requests=False) -> Settings:
         return Settings(
             token=token,
+            actor=actor,
             api_url=api_url,
             graphql_url=graphql_url,
             api_retries=retries,
@@ -264,6 +266,10 @@ class Test(unittest.TestCase):
                 w.write(json.dumps(event, ensure_ascii=False))
 
             self.do_test_get_settings(EVENT_FILE=filepath, expected=self.get_settings(event=event, event_file=filepath))
+
+    def test_get_settings_github_actor(self):
+        self.do_test_get_settings(GITHUB_ACTOR='other-actor', expected=self.get_settings(actor='other-actor'))
+        self.do_test_get_settings(GITHUB_ACTOR=None, expected=self.get_settings(actor='github-actions'))
 
     def test_get_settings_github_api_url(self):
         self.do_test_get_settings(GITHUB_API_URL='https://api.github.onpremise.com', expected=self.get_settings(api_url='https://api.github.onpremise.com'))
@@ -621,6 +627,7 @@ class Test(unittest.TestCase):
                 TEST_CHANGES_LIMIT='10',  # not an int
                 CHECK_NAME='check name',  # defaults to 'Test Results'
                 GITHUB_TOKEN='token',
+                GITHUB_ACTOR='actor',
                 GITHUB_REPOSITORY='repo',
                 COMMIT='commit',  # defaults to get_commit_sha(event, event_name)
                 FILES='all-files',

--- a/python/test/test_publisher.py
+++ b/python/test/test_publisher.py
@@ -77,7 +77,8 @@ class TestPublisher(unittest.TestCase):
         return pr
 
     @staticmethod
-    def create_settings(comment_mode=comment_mode_always,
+    def create_settings(actor='actor',
+                        comment_mode=comment_mode_always,
                         job_summary=True,
                         compare_earlier=True,
                         report_individual_runs=False,
@@ -95,6 +96,7 @@ class TestPublisher(unittest.TestCase):
                         search_pull_requests: bool = False):
         return Settings(
             token=None,
+            actor=actor,
             api_url='https://the-github-api-url',
             graphql_url='https://the-github-graphql-url',
             api_retries=1,
@@ -2608,11 +2610,19 @@ class TestPublisher(unittest.TestCase):
             'body': '## Comment Title\n'
                     'results for commit dee59820\u2003± comparison against base commit 70b5dd18\n',
             'isMinimized': False
-        }
+        },
+        # comment of different actor
+        {
+            'id': 'comment eight',
+            'author': {'login': 'other-actor'},
+            'body': '## Comment Title\n'
+                    'Results for commit dee59820.\u2003± Comparison against base commit 70b5dd18.\n',
+            'isMinimized': False
+        },
     ]
 
     def test_get_action_comments(self):
-        settings = self.create_settings()
+        settings = self.create_settings(actor='github-actions')
         gh, gha, req, repo, commit = self.create_mocks()
         publisher = Publisher(settings, gh, gha)
 
@@ -2620,11 +2630,23 @@ class TestPublisher(unittest.TestCase):
                     for comment in self.comments
                     if comment.get('id') in ['comment one', 'comment five', 'comment seven']]
         actual = publisher.get_action_comments(self.comments, is_minimized=None)
+        self.assertEqual(3, len(expected))
+        self.assertEqual(expected, actual)
 
+    def test_get_action_comments_other_actor(self):
+        settings = self.create_settings(actor='other-actor')
+        gh, gha, req, repo, commit = self.create_mocks()
+        publisher = Publisher(settings, gh, gha)
+
+        expected = [comment
+                    for comment in self.comments
+                    if comment.get('id') == 'comment eight']
+        actual = publisher.get_action_comments(self.comments, is_minimized=None)
+        self.assertEqual(1, len(expected))
         self.assertEqual(expected, actual)
 
     def test_get_action_comments_not_minimized(self):
-        settings = self.create_settings()
+        settings = self.create_settings(actor='github-actions')
         gh, gha, req, repo, commit = self.create_mocks()
         publisher = Publisher(settings, gh, gha)
 
@@ -2632,5 +2654,5 @@ class TestPublisher(unittest.TestCase):
                     for comment in self.comments
                     if comment.get('id') in ['comment one', 'comment seven']]
         actual = publisher.get_action_comments(self.comments, is_minimized=False)
-
+        self.assertEqual(2, len(expected))
         self.assertEqual(expected, actual)


### PR DESCRIPTION
In one of my org projects, I can not use `GITHUB_TOKEN` for API rate limiting issues. So I used GitHub App to authenticate this action.
But the issue in this approach is the action creates a new comment for each run which bloats the PR (I run 3 workflows with this action for each commit, for 10 commits, it creates 30 comments).
In this PR, we are adding support for optionally providing `actor_name`, which will be used to find the correct comment to be replaced. 

I am not totally sure about the naming of this new variable. Please suggest if this needs to be changed. 

And thanks for this awesome action.  