### PR TITLE
Update lxml to 4.9.2

### DIFF
--- a/composite/action.yml
+++ b/composite/action.yml
@@ -189,7 +189,7 @@ runs:
       continue-on-error: true
       with:
         path: ${{ steps.os.outputs.pip-cache }}
-        key: enricomi-publish-action-${{ runner.os }}-${{ runner.arch }}-pip-${{ steps.python.outputs.version }}-b8e8abb8483d74cfe629dd253143f067
+        key: enricomi-publish-action-${{ runner.os }}-${{ runner.arch }}-pip-${{ steps.python.outputs.version }}-af19e6047b0ef2d4ffe0d62d6cefdd99
 
     - name: Install Python dependencies
       run: |

--- a/python/requirements-direct.txt
+++ b/python/requirements-direct.txt
@@ -1,6 +1,6 @@
 humanize==3.14.0
 junitparser==3.1.0
-lxml==4.9.1
+lxml==4.9.2
 psutil==5.9.5
 PyGithub==1.58.2
 requests==2.31.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,7 +1,7 @@
 humanize==3.14.0
 junitparser==3.1.0
   future==0.18.3
-lxml==4.9.1
+lxml==4.9.2
 psutil==5.9.5
 PyGithub==1.58.2
   Deprecated==1.2.13


### PR DESCRIPTION
`lxml` 4.9.1 is not available on Windows for Python v3.11, so the action is not usable on Windows systems running under Python v3.11. Upgrading to `lxml` 4.9.2 fixes this issue.