### PR TITLE
Adds an option to let you specify a test path prefix

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -132,7 +132,10 @@ inputs:
     description: 'Prior to v2.6.0, the action used the "/search/issues" REST API to find pull requests related to a commit. If you need to restore that behaviour, set this to "true". Defaults to "false".'
     default: 'false'
     required: false
-
+  test_file_path_prefix:
+    description: 'The prefix that test file paths have in your results, for example "./" or "/opt/actions-runner"'
+    default: ''
+    required: false
 outputs:
   json:
     description: "Test results as JSON"

--- a/composite/action.yml
+++ b/composite/action.yml
@@ -132,6 +132,11 @@ inputs:
     description: 'Prior to v2.6.0, the action used the "/search/issues" REST API to find pull requests related to a commit. If you need to restore that behaviour, set this to "true". Defaults to "false".'
     default: 'false'
     required: false
+  test_file_path_prefix:
+    description: 'The prefix that test file paths have in your results, for example "./" or "/opt/actions-runner"'
+    default: ""
+    required: false
+
 outputs:
   json:
     description: "Test results as JSON"
@@ -243,6 +248,7 @@ runs:
         JSON_TEST_CASE_RESULTS: ${{ inputs.json_test_case_results }}
         JOB_SUMMARY: ${{ inputs.job_summary }}
         SEARCH_PULL_REQUESTS: ${{ inputs.search_pull_requests }}
+        TEST_FILE_PATH_PREFIX: ${{ inputs.test_file_path_prefix }}
         # not documented
         ROOT_LOG_LEVEL: ${{ inputs.root_log_level }}
         # not documented

--- a/python/publish/__init__.py
+++ b/python/publish/__init__.py
@@ -770,7 +770,8 @@ def get_case_annotation(messages: CaseMessages,
                         key: Tuple[Optional[str], Optional[str], Optional[str]],
                         state: str,
                         message: Optional[str],
-                        report_individual_runs: bool) -> Annotation:
+                        report_individual_runs: bool,
+                        test_file_path_prefix: str) -> Annotation:
     case = messages[key][state][message][0]
     same_cases = len(messages[key][state][message] if report_individual_runs else
                      [case
@@ -786,7 +787,7 @@ def get_case_annotation(messages: CaseMessages,
                                        for m in messages[key][state]
                                        for c in messages[key][state][m]])
                          if case.result_file}
-    test_file = case.test_file
+    test_file = case.test_file.replace(test_file_path_prefix, "", 1)
     line = case.line or 0
     test_name = case.test_name if case.test_name else 'Unknown test'
     class_name = case.class_name
@@ -832,10 +833,11 @@ def get_case_annotation(messages: CaseMessages,
 
 
 def get_case_annotations(case_results: UnitTestCaseResults,
-                         report_individual_runs: bool) -> List[Annotation]:
+                         report_individual_runs: bool,
+                         test_file_path_prefix: str) -> List[Annotation]:
     messages = get_case_messages(case_results)
     return [
-        get_case_annotation(messages, key, state, message, report_individual_runs)
+        get_case_annotation(messages, key, state, message, report_individual_runs, test_file_path_prefix)
         for key in messages
         for state in messages[key] if state not in ['success', 'skipped']
         for message in (messages[key][state] if report_individual_runs else
@@ -843,9 +845,9 @@ def get_case_annotations(case_results: UnitTestCaseResults,
     ]
 
 
-def get_error_annotation(error: ParseError) -> Annotation:
+def get_error_annotation(error: ParseError, test_path_file_prefix: str) -> Annotation:
     return Annotation(
-        path=error.file,
+        path=error.file.replace(test_path_file_prefix, '', 1),
         start_line=error.line or 0,
         end_line=error.line or 0,
         start_column=error.column,
@@ -857,8 +859,8 @@ def get_error_annotation(error: ParseError) -> Annotation:
     )
 
 
-def get_error_annotations(parse_errors: List[ParseError]) -> List[Annotation]:
-    return [get_error_annotation(error) for error in parse_errors]
+def get_error_annotations(parse_errors: List[ParseError], test_path_file_prefix: str) -> List[Annotation]:
+    return [get_error_annotation(error, test_path_file_prefix) for error in parse_errors]
 
 
 def get_suite_annotations_for_suite(suite: UnitTestSuite, with_suite_out_logs: bool, with_suite_err_logs: bool) -> List[Annotation]:

--- a/python/publish/publisher.py
+++ b/python/publish/publisher.py
@@ -72,6 +72,7 @@ class Settings:
     seconds_between_github_reads: float
     seconds_between_github_writes: float
     search_pull_requests: bool
+    test_file_path_prefix: str
 
 
 @dataclasses.dataclass(frozen=True)
@@ -395,8 +396,8 @@ class Publisher:
         stats_with_delta = get_stats_delta(stats, before_stats, 'earlier') if before_stats is not None else stats
         logger.debug(f'stats with delta: {stats_with_delta}')
 
-        error_annotations = get_error_annotations(stats.errors)
-        case_annotations = get_case_annotations(cases, self._settings.report_individual_runs)
+        error_annotations = get_error_annotations(stats.errors, self._settings.test_file_path_prefix)
+        case_annotations = get_case_annotations(cases, self._settings.report_individual_runs, self._settings.test_file_path_prefix)
         output_annotations = get_suite_annotations(stats.suite_details, self._settings.report_suite_out_logs, self._settings.report_suite_err_logs)
         test_list_annotations = self.get_test_list_annotations(cases)
         all_annotations = error_annotations + case_annotations + output_annotations + test_list_annotations

--- a/python/publish_test_results.py
+++ b/python/publish_test_results.py
@@ -457,6 +457,8 @@ def get_settings(options: dict, gha: GithubAction) -> Settings:
     check_var_condition(is_float(seconds_between_github_reads), f'SECONDS_BETWEEN_GITHUB_READS must be a positive number: {seconds_between_github_reads}')
     check_var_condition(is_float(seconds_between_github_writes), f'SECONDS_BETWEEN_GITHUB_WRITES must be a positive number: {seconds_between_github_writes}')
 
+    test_file_path_prefix = get_var('TEST_FILE_PATH_PREFIX', options) or ''
+
     settings = Settings(
         token=get_var('GITHUB_TOKEN', options),
         actor=get_var('GITHUB_TOKEN_ACTOR', options) or 'github-actions',
@@ -499,7 +501,8 @@ def get_settings(options: dict, gha: GithubAction) -> Settings:
         check_run_annotation=annotations,
         seconds_between_github_reads=float(seconds_between_github_reads),
         seconds_between_github_writes=float(seconds_between_github_writes),
-        search_pull_requests=get_bool_var('SEARCH_PULL_REQUESTS', options, default=False)
+        search_pull_requests=get_bool_var('SEARCH_PULL_REQUESTS', options, default=False),
+        test_file_path_prefix=test_file_path_prefix
     )
 
     check_var(settings.token, 'GITHUB_TOKEN', 'GitHub token')


### PR DESCRIPTION
This takes care of the removal side of https://github.com/EnricoMi/publish-unit-test-result-action/issues/452, I think.

Right now if your test file paths start with, e.g. `./`, then the annotations don't get properly associated to the files. This lets you specify the extraneous prefix in your paths and strips it out when creating the annotations.

I tested the composite action and it worked on my repository, where our JUnit files are prefixed with `./`. I'm not sure how to test the docker version, though.