### PR TITLE
Fix spelling issues

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -288,7 +288,7 @@ jobs:
           INPUT_JSON_FILE: "tests.json"
           INPUT_JSON_SUITE_DETAILS: true
           INPUT_JSON_TEST_CASE_RESULTS: true
-          INPUT_REPORT_SUTE_LOGS: "any"
+          INPUT_REPORT_SUITE_LOGS: "any"
         run: |
           docker run \
             --workdir $GITHUB_WORKSPACE \

--- a/python/publish/dart.py
+++ b/python/publish/dart.py
@@ -107,7 +107,7 @@ def parse_dart_json_file(path: str) -> JUnitTree:
 
         return testsuite
 
-    # do not count hidden tests (unless not successfull)
+    # do not count hidden tests (unless not successful)
     visible_tests = [test for test in tests.values() if test.get('hidden') is not True or test.get('result') != 'success']
     testsuites = etree.Element('testsuites', attrib={k: str(v) for k, v in dict(
         time=(suite_time - suite_start) / 1000.0 if suite_start is not None and suite_time is not None else None,


### PR DESCRIPTION
... and another typo.

[_source_](https://github.com/szepeviktor/byte-level-care/blob/master/.github/workflows/spelling.yml)

There were two typos excluding `python/test/files/*` files.
In `python/test/files` there are 1044 additional typos.
What to do now?
