### PR TITLE
Drop excessive output from `action_fail`

### DIFF
--- a/python/publish_test_results.py
+++ b/python/publish_test_results.py
@@ -263,8 +263,6 @@ def main(settings: Settings, gha: GithubAction) -> None:
 
     if action_fail_required(conclusion, settings.action_fail, settings.action_fail_on_inconclusive):
         gha.error(f'This action finished successfully, but test results have status {conclusion}.')
-        gha.error(f'Configuration requires this action to fail (action_fail={settings.action_fail}, '
-                  f'action_fail_on_inconclusive={settings.action_fail_on_inconclusive}).')
         sys.exit(1)
 
 


### PR DESCRIPTION
## What

Drop excessive output from when `action_fail` is enabled.

## Why

As a job with many such steps (different kinds of tests) becomes very verbose and hard to get an overview of.

Here's an example of such output:
>Configuration requires this action to fail (action_fail=True, action_fail_on_inconclusive=False).
i.e:

>![Skärmavbild 2023-10-06 kl  14 53 18](https://github.com/EnricoMi/publish-unit-test-result-action/assets/62675/66e0699f-b913-495e-9f9b-4eb109195d31)
