### PR TITLE
Publish ARM images

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -140,6 +140,7 @@ jobs:
         with:
           tags: ${{ steps.docker-meta.outputs.tags }}
           labels: ${{ steps.docker-meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
           pull: true
           # deploy image actions from commits pushed to master and
           # deploy Dockerfile actions from pushed version tags (no major versions)


### PR DESCRIPTION
Allow the action to run on self-hosted ARM64 workers, compatible with AWS Graviton ARM instances.