### PR TITLE
Upgrade CI and Python dependencies

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -27,7 +27,7 @@ runs:
         python-version: ${{ inputs.python-version }}
   
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
   
     - name: Detect OS
       id: os

--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get package downloads
         id: downloads
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Fetch workflows
         id: workflows

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Check requirements.txt against requirements-direct.txt
         run: |
           (diff -w python/requirements-direct.txt python/requirements.txt || true) | (! grep -e "^<")
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Extract action image and version
         # we deploy from a specific commit on master (the one that mentions a new version the first time)

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -109,7 +109,7 @@ jobs:
     steps:
       - name: Docker meta
         id: docker-meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/EnricoMi/publish-unit-test-result-action
           flavor: |
@@ -157,7 +157,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Event File
           path: ${{ github.event_path }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -123,20 +123,20 @@ jobs:
             type=semver,pattern={{version}},value=${{ needs.config-deploy.outputs.image-version }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           tags: ${{ steps.docker-meta.outputs.tags }}
           labels: ${{ steps.docker-meta.outputs.labels }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -157,7 +157,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: Event File
           path: ${{ github.event_path }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -46,7 +46,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -60,4 +60,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download Artifacts
         uses: actions/download-artifact@v3
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -257,7 +257,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
         if: matrix.python != 'installed'
@@ -298,7 +298,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Copy test result files
         run: cp -rv python/test/files test-files
@@ -344,7 +344,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Copy test junit xml files
         run: cp -rv python/test/files/junit-xml test-files

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
 
@@ -66,11 +66,11 @@ jobs:
           platforms: ${{ matrix.arch }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build Docker image
         id: build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           load: true
           push: false
@@ -79,7 +79,7 @@ jobs:
           outputs: type=docker
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
 
@@ -204,13 +204,13 @@ jobs:
           dockerfile: ./Dockerfile
           annotations: true
       - name: Upload SARIF artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: SARIF
           path: ${{ steps.scan.outputs.sarif }}
       - name: Upload SARIF file
         if: always() && steps.scan.outputs.sarif != ''
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
 
@@ -261,12 +261,12 @@ jobs:
 
       - name: Setup Python
         if: matrix.python != 'installed'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -198,7 +198,7 @@ jobs:
 
       - name: Scan for vulnerabilities
         id: scan
-        uses: crazy-max/ghaction-container-scan@v2
+        uses: crazy-max/ghaction-container-scan@v3
         with:
           image: enricomi/publish-unit-test-result-action:latest
           dockerfile: ./Dockerfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           path: artifacts
 
@@ -79,7 +79,7 @@ jobs:
           outputs: type=docker
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           path: artifacts
 
@@ -204,7 +204,7 @@ jobs:
           dockerfile: ./Dockerfile
           annotations: true
       - name: Upload SARIF artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: SARIF
           path: ${{ steps.scan.outputs.sarif }}
@@ -266,7 +266,7 @@ jobs:
           python-version: ${{ matrix.python }}
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           path: artifacts
 

--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Test
         uses: ./.github/actions/test

--- a/composite/action.yml
+++ b/composite/action.yml
@@ -197,7 +197,7 @@ runs:
       continue-on-error: true
       with:
         path: ${{ steps.os.outputs.pip-cache }}
-        key: enricomi-publish-action-${{ runner.os }}-${{ runner.arch }}-pip-${{ steps.python.outputs.version }}-df386fe4e04a72c96e140f0566a5c849
+        key: enricomi-publish-action-${{ runner.os }}-${{ runner.arch }}-pip-${{ steps.python.outputs.version }}-fc884bb0b8d89fb24ccb9a84a3d97821
 
     - name: Create virtualenv
       id: venv

--- a/python/requirements-direct.txt
+++ b/python/requirements-direct.txt
@@ -1,5 +1,5 @@
 humanize==3.14.0
 junitparser==3.1.0
 lxml==4.9.3
-psutil==5.9.5
+psutil==5.9.7
 PyGithub==2.1.1

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -8,6 +8,7 @@ PyGithub==2.1.1
     wrapt==1.16.0
   PyJWT==2.8.0
   PyNaCl==1.5.0
+    # latest version that support Python 3.7
     cffi==1.15.1
       pycparser==2.21
   python-dateutil==2.8.2
@@ -16,6 +17,9 @@ PyGithub==2.1.1
     certifi==2023.11.17
     charset-normalizer==3.3.2
     idna==3.6
+    # latest version that support Python 3.7
     urllib3==2.0.7
-  typing_extensions==4.9.0
+  # latest version that support Python 3.7
+  typing_extensions==4.7.1
+  # latest version that support Python 3.7
   urllib3==2.0.7

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -8,7 +8,7 @@ PyGithub==2.1.1
     wrapt==1.16.0
   PyJWT==2.8.0
   PyNaCl==1.5.0
-    cffi==1.16.0
+    cffi==1.15.1
       pycparser==2.21
   python-dateutil==2.8.2
     six==1.16.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,10 +2,10 @@ humanize==3.14.0
 junitparser==3.1.0
   future==0.18.3
 lxml==4.9.3
-psutil==5.9.5
+psutil==5.9.7
 PyGithub==2.1.1
   Deprecated==1.2.14
-    wrapt==1.15.0
+    wrapt==1.16.0
   PyJWT==2.8.0
   PyNaCl==1.5.0
     cffi==1.16.0
@@ -13,9 +13,9 @@ PyGithub==2.1.1
   python-dateutil==2.8.2
     six==1.16.0
   requests==2.31.0
-    certifi==2023.7.22
-    charset-normalizer==3.3.0
-    idna==3.4
-    urllib3==2.0.7
-  typing_extensions==4.8.0
-  urllib3==2.0.7
+    certifi==2023.11.17
+    charset-normalizer==3.3.2
+    idna==3.6
+    urllib3==2.1.0
+  typing_extensions==4.9.0
+  urllib3==2.1.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -16,6 +16,6 @@ PyGithub==2.1.1
     certifi==2023.11.17
     charset-normalizer==3.3.2
     idna==3.6
-    urllib3==2.1.0
+    urllib3==2.0.7
   typing_extensions==4.9.0
-  urllib3==2.1.0
+  urllib3==2.0.7

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -8,7 +8,7 @@ PyGithub==2.1.1
     wrapt==1.15.0
   PyJWT==2.8.0
   PyNaCl==1.5.0
-    cffi==1.15.1
+    cffi==1.16.0
       pycparser==2.21
   python-dateutil==2.8.2
     six==1.16.0
@@ -16,6 +16,6 @@ PyGithub==2.1.1
     certifi==2023.7.22
     charset-normalizer==3.3.0
     idna==3.4
-    urllib3==2.0.6
-  typing_extensions==4.7.1
-  urllib3==2.0.6
+    urllib3==2.0.7
+  typing_extensions==4.8.0
+  urllib3==2.0.7


### PR DESCRIPTION
fix #498

Hi @EnricoMi,
I just discovered this project.

This PR upgrades the `checkout` action to release v4. I also used the [`upgrade-pip-packages.sh`](https://github.com/EnricoMi/publish-unit-test-result-action/blob/d826f852b6b65be05c9bcc086cfc7e181255d464/.github/upgrade-pip-packages.sh) script to upgrade the pip dependencies.

I hope that this PR might be helpful. I'd be grateful if you would consider sharing your feedback on this below.