### PR TITLE
feat: Always publish json output and file if json_file is set

### DIFF
--- a/python/publish/publisher.py
+++ b/python/publish/publisher.py
@@ -412,10 +412,10 @@ class Publisher:
         title = get_short_summary(stats)
         summary = get_long_summary_md(stats_with_delta)
 
+        check_run = None
         if self._settings.check_run:
             # only publish check run if it is enabled, else we only publish json output & json file
             # we can send only 50 annotations at once, so we split them into chunks of 50
-            check_run = None
             summary_with_digest = get_long_summary_with_digest_md(stats_with_delta, stats)
             split_annotations = [annotation.to_dict() for annotation in all_annotations]
             split_annotations = [split_annotations[x:x+50] for x in range(0, len(split_annotations), 50)] or [[]]

--- a/python/test/test_publisher.py
+++ b/python/test/test_publisher.py
@@ -1380,12 +1380,12 @@ class TestPublisher(unittest.TestCase):
             with mock.patch('gzip.time.time', return_value=0):
                 check_run, before_check_run = publisher.publish_check(self.stats, self.cases, 'conclusion')
 
-                repo.create_check_run.assert_not_called()
+            repo.create_check_run.assert_not_called()
 
-                self.assertIsNone(check_run, "check_run should be None when check_run is False")
+            self.assertIsNone(check_run, "check_run should be None when check_run is False")
 
-                # assert the json file has been created
-                self.assertTrue(os.path.isfile(filepath), "json file should have been created")
+            # assert the json file has been created
+            self.assertTrue(os.path.isfile(filepath), "json file should have been created")
 
 
     def do_test_publish_check_with_base_stats(self, errors: List[ParseError]):

--- a/python/test/test_publisher.py
+++ b/python/test/test_publisher.py
@@ -1381,10 +1381,7 @@ class TestPublisher(unittest.TestCase):
                 check_run, before_check_run = publisher.publish_check(self.stats, self.cases, 'conclusion')
 
             repo.create_check_run.assert_not_called()
-
-            self.assertIsNone(check_run, "check_run should be None when check_run is False")
-
-            # assert the json file has been created
+            self.assertIsNone(check_run, "check_run should be None when check_run input is False")
             self.assertTrue(os.path.isfile(filepath), "json file should have been created")
 
 

--- a/python/test/test_publisher.py
+++ b/python/test/test_publisher.py
@@ -1369,6 +1369,25 @@ class TestPublisher(unittest.TestCase):
     def test_publish_check_with_base_stats_with_errors(self):
         self.do_test_publish_check_with_base_stats(errors)
 
+    def test_publish_check_with_json_file_without_check_run(self):
+        with tempfile.TemporaryDirectory() as path:
+            filepath = os.path.join(path, 'file.json')
+            settings = self.create_settings(check_run=False, json_file=filepath)
+            gh, gha, req, repo, commit = self.create_mocks(commit=mock.Mock(), digest=self.past_digest, check_names=[settings.check_name])
+            publisher = Publisher(settings, gh, gha)
+
+            # makes gzipped digest deterministic
+            with mock.patch('gzip.time.time', return_value=0):
+                check_run, before_check_run = publisher.publish_check(self.stats, self.cases, 'conclusion')
+
+                repo.create_check_run.assert_not_called()
+
+                self.assertIsNone(check_run, "check_run should be None when check_run is False")
+
+                # assert the json file has been created
+                self.assertTrue(os.path.isfile(filepath), "json file should have been created")
+
+
     def do_test_publish_check_with_base_stats(self, errors: List[ParseError]):
         earlier_commit = 'past'
         settings = self.create_settings(event={'before': earlier_commit})

--- a/python/test/test_publisher.py
+++ b/python/test/test_publisher.py
@@ -1381,6 +1381,7 @@ class TestPublisher(unittest.TestCase):
                 check_run, before_check_run = publisher.publish_check(self.stats, self.cases, 'conclusion')
 
             repo.create_check_run.assert_not_called()
+            gha.add_to_output.assert_called_once()
             self.assertIsNone(check_run, "check_run should be None when check_run input is False")
             self.assertTrue(os.path.isfile(filepath), "json file should have been created")
 


### PR DESCRIPTION
Publish json output (and json_file) if json_file is set

As it is now, the json file is only published if `check_run` is set to true, which this PR changes. Now it will also publish even if `check_run` is false, as long as `json_file` is set.

An alternative would be to add a new setting called `publish_check_run` (default `true` for backwards compatibility), which would be used to decide if the check is published. Then if you want the json output without publishing the check run (in my case we can't use it, since it publishes to an incorrect workflow), you could set `check_run` to `true`, but override `publish_check_run` to `false`

Related issue: https://github.com/EnricoMi/publish-unit-test-result-action/issues/554