### PR TITLE
Support debian 12

### DIFF
--- a/composite/action.yml
+++ b/composite/action.yml
@@ -210,8 +210,10 @@ runs:
         PIP_OPTIONS: ${{ steps.os.outputs.pip-options }}
       run: |
         echo '##[group]Create virtualenv'
-        # install virtualenv, if it is not yet installed
-        python3 -m pip install $PIP_OPTIONS virtualenv
+        # install virtualenv, if it is not yet installed        
+        if [[ -z $(dpkg -l | grep python3-virtualenv) ]]; then
+          python3 -m pip install $PIP_OPTIONS virtualenv
+        fi
         python3 -m virtualenv enricomi-publish-action-venv
         # test activating virtualenv
         case "$RUNNER_OS" in


### PR DESCRIPTION
Hi @EnricoMi 

on debian12 ```pip``` outside of virtual environments is not supported anymore, so the first ```pip install``` call in the composite/action.yml fails.
As far as I found out only python3 3.11 is available on debian12

## Setup
docker image: ```debian:bookworm-slim``` 

installed packages:
 - python3-full
 - python3-pip
```shell
root@f676d2dc4a1c:/_setup# cat /etc/os-release
PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
NAME="Debian GNU/Linux"
VERSION_ID="12"
VERSION="12 (bookworm)"
VERSION_CODENAME=bookworm
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```

## Error
received error message:
```shell
root@172b694a026a:/_setup# python3 -m pip install virtualenv
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.

    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.

    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.

    See /usr/share/doc/python3.11/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```

## Proposal

```python3-virtualenv``` has to be preinstalled on debian12 so the virtualenv is created and the pip commands are executed inside of it.
This also should be backwards compatible so users without preinstalled ```python3-virtualenv``` can still use it in prior versions.

```shell
apt-get update
apt-get install -y python3-virtualenv
python3 -m virtualenv enricomi-publish-action-venv
source enricomi-publish-action-venv/bin/activate

(enricomi-publish-action-venv)> python3 -m pip wheel # pip works in venv
```

Thanks for considering this or any better approach to fix this,
Max