### PR TITLE
Quote python bin in windows bash action

### DIFF
--- a/windows/bash/action.yml
+++ b/windows/bash/action.yml
@@ -176,7 +176,7 @@ runs:
         echo "Python that creates venv: $PYTHON_BIN"
         echo "PYTHON_BIN=$PYTHON_BIN" >> "$GITHUB_ENV"
 
-        PYTHON_VERSION="$($PYTHON_BIN -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+        PYTHON_VERSION="$("$PYTHON_BIN" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
         if [[ "$PYTHON_VERSION" == "3.7" ]]
         then
           echo "DEPENDENCIES_VERSION=3.7" >> "$GITHUB_ENV"


### PR DESCRIPTION
In #585 the python bin got unquoted, leading to #586:
https://github.com/EnricoMi/publish-unit-test-result-action/blob/466ab0b314344b3e139d89f65e65980baedf587a/windows/bash/action.yml#L179

Fixes #586.