### PR TITLE
Quote `$PYTHON_BIN` in deprecated composite action

### DIFF
--- a/composite/action.yml
+++ b/composite/action.yml
@@ -182,7 +182,7 @@ runs:
         echo "Python that creates venv: $PYTHON_BIN"
         echo "PYTHON_BIN=$PYTHON_BIN" >> "$GITHUB_ENV"
 
-        PYTHON_VERSION="$($PYTHON_BIN -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+        PYTHON_VERSION="$("$PYTHON_BIN" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
         if [[ "$PYTHON_VERSION" == "3.7" ]]; then
           echo "DEPENDENCIES_VERSION=3.7" >> "$GITHUB_ENV"
         elif [[ "$PYTHON_VERSION" == "3.8" ]]; then


### PR DESCRIPTION
This applies #587 to the deprecated composite action. Fixes the deprecated composite action for hosts where Python is installed in paths containing spaces, Windows is most likely affected.