### PR TITLE
Add composite replacement to `README.md`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -466,7 +466,7 @@ jobs:
         id: test-results
         uses: ./composite
         with:
-          check_name: Test Results (${{ matrix.os-label }} composite python ${{ matrix.python }})
+          check_name: Test Results (${{ matrix.os-label }} composite)
           files: |
             artifacts/**/*.xml
             artifacts\**\*.xml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -475,6 +475,30 @@ jobs:
           json_test_case_results: true
           report_suite_logs: "any"
 
+      - name: Publish if Linux
+        uses: ./linux
+        if: runner.os == 'Linux'
+        with:
+          check_name: Test Results if Linux
+          comment_mode: off
+          files: artifacts/**/*.xml
+
+      - name: Publish if macOS
+        uses: ./macos
+        if: runner.os == 'macOS'
+        with:
+          check_name: Test Results if macOS
+          comment_mode: off
+          files: artifacts/**/*.xml
+
+      - name: Publish if Windows
+        uses: ./windows/bash
+        if: runner.os == 'Windows'
+        with:
+          check_name: Test Results if Windows
+          comment_mode: off
+          files: artifacts\**\*.xml
+
       - name: JSON output
         uses: ./misc/action/json-output
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -475,30 +475,6 @@ jobs:
           json_test_case_results: true
           report_suite_logs: "any"
 
-      - name: Publish if Linux
-        uses: ./linux
-        if: runner.os == 'Linux'
-        with:
-          check_name: Test Results if Linux
-          comment_mode: off
-          files: artifacts/**/*.xml
-
-      - name: Publish if macOS
-        uses: ./macos
-        if: runner.os == 'macOS'
-        with:
-          check_name: Test Results if macOS
-          comment_mode: off
-          files: artifacts/**/*.xml
-
-      - name: Publish if Windows
-        uses: ./windows/bash
-        if: runner.os == 'Windows'
-        with:
-          check_name: Test Results if Windows
-          comment_mode: off
-          files: artifacts\**\*.xml
-
       - name: JSON output
         uses: ./misc/action/json-output
         with:

--- a/README.md
+++ b/README.md
@@ -42,10 +42,7 @@ Use this for ![macOS](misc/badge-macos.svg) (e.g. `runs-on: macos-latest`) runne
   uses: EnricoMi/publish-unit-test-result-action/macos@v2
   if: always()
   with:
-    files: |
-      test-results/**/*.xml
-      test-results/**/*.trx
-      test-results/**/*.json
+    files: …
 ```
 
 … and ![Windows](misc/badge-windows.svg) (e.g. `runs-on: windows-latest`) runners (no Docker needed):
@@ -54,10 +51,7 @@ Use this for ![macOS](misc/badge-macos.svg) (e.g. `runs-on: macos-latest`) runne
   uses: EnricoMi/publish-unit-test-result-action/windows@v2
   if: always()
   with:
-    files: |
-      test-results\**\*.xml
-      test-results\**\*.trx
-      test-results\**\*.json
+    files: …
 ```
 
 For Windows **without PowerShell** installed, there is the Bash shell variant:
@@ -66,10 +60,7 @@ For Windows **without PowerShell** installed, there is the Bash shell variant:
   uses: EnricoMi/publish-unit-test-result-action/windows/bash@v2
   if: always()
   with:
-    files: |
-      test-results\**\*.xml
-      test-results\**\*.trx
-      test-results\**\*.json
+    files: …
 ```
 
 For **self-hosted** Linux GitHub Actions runners **without Docker** installed, please use:
@@ -78,10 +69,7 @@ For **self-hosted** Linux GitHub Actions runners **without Docker** installed, p
   uses: EnricoMi/publish-unit-test-result-action/linux@v2
   if: always()
   with:
-    files: |
-      test-results/**/*.xml
-      test-results/**/*.trx
-      test-results/**/*.json
+    files: …
 ```
 
 See the [notes on running this action as a non-Docker action](#running-as-a-non-docker-action).

--- a/README.md
+++ b/README.md
@@ -876,19 +876,19 @@ The same behaviour can be achieved with multiple steps, each for a specific oper
 
 ```yaml
 - name: Publish Test Results
-  uses: ./linux
+  uses: EnricoMi/publish-unit-test-result-action/linux@2
   if: runner.os == 'Linux'
   with:
     files: test-results/**/*.xml
 
 - name: Publish Test Results
-  uses: ./macos
+  uses: EnricoMi/publish-unit-test-result-action/macos@2
   if: runner.os == 'macOS'
   with:
     files: test-results/**/*.xml
 
 - name: Publish Test Results
-  uses: ./windows/bash
+  uses: EnricoMi/publish-unit-test-result-action/windows/bash@2
   if: runner.os == 'Windows'
   with:
     files: test-results/**/*.xml

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ or ![ARM Linux](misc/badge-arm.svg) self-hosted runners that support Docker:
 
 See the [notes on running this action with absolute paths](#running-with-absolute-paths) if you cannot use relative test result file paths.
 
-Use this for ![macOS](misc/badge-macos.svg) (e.g. `runs-on: macos-latest`) runners:
+Use this for ![macOS](misc/badge-macos.svg) (e.g. `runs-on: macos-latest`) runners (no Docker needed):
 ```yaml
 - name: Publish Test Results
   uses: EnricoMi/publish-unit-test-result-action/macos@v2
@@ -48,10 +48,22 @@ Use this for ![macOS](misc/badge-macos.svg) (e.g. `runs-on: macos-latest`) runne
       test-results/**/*.json
 ```
 
-… and ![Windows](misc/badge-windows.svg) (e.g. `runs-on: windows-latest`) runners:
+… and ![Windows](misc/badge-windows.svg) (e.g. `runs-on: windows-latest`) runners (no Docker needed):
 ```yaml
 - name: Publish Test Results
   uses: EnricoMi/publish-unit-test-result-action/windows@v2
+  if: always()
+  with:
+    files: |
+      test-results\**\*.xml
+      test-results\**\*.trx
+      test-results\**\*.json
+```
+
+For Windows **without PowerShell** installed, there is the Bash shell variant:
+```yaml
+- name: Publish Test Results
+  uses: EnricoMi/publish-unit-test-result-action/windows/bash@v2
   if: always()
   with:
     files: |

--- a/README.md
+++ b/README.md
@@ -870,3 +870,26 @@ is **deprecated**, please use an action appropriate for your operating system an
 - Windows (Bash shell): `uses: EnricoMi/publish-unit-test-result-action/windows/bash@v2`
 
 These are non-Docker variations of this action. For details, see section ["Running as a non-Docker action"](#running-as-a-non-docker-action) above.
+
+The composite action was able to run on any operating system, as long as Bash shell is installed.
+The same behaviour can be achieved with multiple steps, each for a specific operating system:
+
+```yaml
+- name: Publish Test Results
+  uses: ./linux
+  if: runner.os == 'Linux'
+  with:
+    files: test-results/**/*.xml
+
+- name: Publish Test Results
+  uses: ./macos
+  if: runner.os == 'macOS'
+  with:
+    files: test-results/**/*.xml
+
+- name: Publish Test Results
+  uses: ./windows/bash
+  if: runner.os == 'Windows'
+  with:
+    files: test-results/**/*.xml
+```


### PR DESCRIPTION
This adds example workflow YAML to provide an example of how to replace the composite action with OS-specific actions in a multi-OS job. Further mentions the Windows Bash action at the to of the `README.md`.