### PR TITLE
Add action typing

### DIFF
--- a/.github/workflows/check-action-typing.yml
+++ b/.github/workflows/check-action-typing.yml
@@ -1,0 +1,31 @@
+name: Check Action Typing
+
+on:
+  push:
+    branches:
+      - 'master*'
+      - 'devel-*'
+    tags:
+      - '*'
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  check-action-typing:
+    name: Check Action Typing
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check Action Typing
+        uses: typesafegithub/github-actions-typing@0dc5690c35c564d354dc0c23c56559f0813ed3ac  # v2.2.0
+        with:
+          ignored-action-files: |-
+            .github/actions/test/action.yml
+            misc/action/fetch-workflows/action.yml
+            misc/action/find-workflows/action.yml
+            misc/action/json-output/action.yml
+            misc/action/package-downloads/action.yml

--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ Otherwise, the multiple runs overwrite each other's results.
 The action that executed the tests should fail on test failure. The published results however indicate failure if tests fail or errors occur,
 which can be [configured](#configuration) via `fail_on`.*
 
+Thanks to the provided [typings](action-types.yml), it is possible to use this action in a type-safe way using
+[GitHub Workflows Kt](https://github.com/typesafegithub/github-workflows-kt), which allows writing workflow files using a type-safe Kotlin DSL.
+
 ## Permissions
 
 Minimal [workflow job permissions](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#example-setting-permissions-for-a-specific-job)

--- a/action-types.yml
+++ b/action-types.yml
@@ -1,0 +1,173 @@
+# See https://github.com/typesafegithub/github-actions-typing/
+inputs:
+  github_token:
+    type: string
+
+  github_token_actor:
+    type: string
+
+  github_retries:
+    type: integer
+
+  ssl_verify:
+    type: boolean
+
+  commit:
+    type: string
+
+  check_name:
+    type: string
+
+  comment_title:
+    type: string
+
+  comment_mode:
+    type: enum
+    allowed-values:
+      - always
+      - changes
+      - changes in failures
+      - changes in errors
+      - failures
+      - errors
+      - off
+
+  fail_on:
+    type: enum
+    allowed-values:
+      - nothing
+      - errors
+      - test failures
+
+  action_fail:
+    type: boolean
+
+  action_fail_on_inconclusive:
+    type: boolean
+
+  files:
+    type: list
+    separator: '\n'
+    list-item:
+      type: string
+
+  junit_files:
+    type: list
+    separator: '\n'
+    list-item:
+      type: string
+
+  nunit_files:
+    type: list
+    separator: '\n'
+    list-item:
+      type: string
+
+  xunit_files:
+    type: list
+    separator: '\n'
+    list-item:
+      type: string
+
+  trx_files:
+    type: list
+    separator: '\n'
+    list-item:
+      type: string
+
+  time_unit:
+    type: enum
+    allowed-values:
+      - seconds
+      - milliseconds
+
+  test_file_prefix:
+    type: string
+
+  report_individual_runs:
+    type: boolean
+
+  report_suite_logs:
+    type: enum
+    allowed-values:
+      - info
+      - error
+      - any
+      - none
+
+  deduplicate_classes_by_file_name:
+    type: boolean
+
+  large_files:
+    type: boolean
+
+  ignore_runs:
+    type: boolean
+
+  check_run:
+    type: boolean
+
+  job_summary:
+    type: boolean
+
+  compare_to_earlier_commit:
+    type: boolean
+
+  pull_request_build:
+    type: enum
+    allowed-values:
+      - commit
+      - merge
+
+  event_file:
+    type: string
+
+  event_name:
+    type: string
+
+  test_changes_limit:
+    type: integer
+
+  check_run_annotations:
+    type: list
+    separator: ','
+    list-item:
+      type: enum
+      allowed-values:
+        - all tests
+        - skipped tests
+        - none
+
+  check_run_annotations_branch:
+    type: list
+    separator: ','
+    list-item:
+      type: string
+
+  seconds_between_github_reads:
+    type: float
+
+  seconds_between_github_writes:
+    type: float
+
+  secondary_rate_limit_wait_seconds:
+    type: float
+
+  json_file:
+    type: string
+
+  json_thousands_separator:
+    type: string
+
+  json_suite_details:
+    type: boolean
+
+  json_test_case_results:
+    type: boolean
+
+  search_pull_requests:
+    type: boolean
+
+outputs:
+  json:
+    type: string

--- a/composite/action-types.yml
+++ b/composite/action-types.yml
@@ -1,0 +1,173 @@
+# See https://github.com/typesafegithub/github-actions-typing/
+inputs:
+  github_token:
+    type: string
+
+  github_token_actor:
+    type: string
+
+  github_retries:
+    type: integer
+
+  ssl_verify:
+    type: boolean
+
+  commit:
+    type: string
+
+  check_name:
+    type: string
+
+  comment_title:
+    type: string
+
+  comment_mode:
+    type: enum
+    allowed-values:
+      - always
+      - changes
+      - changes in failures
+      - changes in errors
+      - failures
+      - errors
+      - off
+
+  fail_on:
+    type: enum
+    allowed-values:
+      - nothing
+      - errors
+      - test failures
+
+  action_fail:
+    type: boolean
+
+  action_fail_on_inconclusive:
+    type: boolean
+
+  files:
+    type: list
+    separator: '\n'
+    list-item:
+      type: string
+
+  junit_files:
+    type: list
+    separator: '\n'
+    list-item:
+      type: string
+
+  nunit_files:
+    type: list
+    separator: '\n'
+    list-item:
+      type: string
+
+  xunit_files:
+    type: list
+    separator: '\n'
+    list-item:
+      type: string
+
+  trx_files:
+    type: list
+    separator: '\n'
+    list-item:
+      type: string
+
+  time_unit:
+    type: enum
+    allowed-values:
+      - seconds
+      - milliseconds
+
+  test_file_prefix:
+    type: string
+
+  report_individual_runs:
+    type: boolean
+
+  report_suite_logs:
+    type: enum
+    allowed-values:
+      - info
+      - error
+      - any
+      - none
+
+  deduplicate_classes_by_file_name:
+    type: boolean
+
+  large_files:
+    type: boolean
+
+  ignore_runs:
+    type: boolean
+
+  check_run:
+    type: boolean
+
+  job_summary:
+    type: boolean
+
+  compare_to_earlier_commit:
+    type: boolean
+
+  pull_request_build:
+    type: enum
+    allowed-values:
+      - commit
+      - merge
+
+  event_file:
+    type: string
+
+  event_name:
+    type: string
+
+  test_changes_limit:
+    type: integer
+
+  check_run_annotations:
+    type: list
+    separator: ','
+    list-item:
+      type: enum
+      allowed-values:
+        - all tests
+        - skipped tests
+        - none
+
+  check_run_annotations_branch:
+    type: list
+    separator: ','
+    list-item:
+      type: string
+
+  seconds_between_github_reads:
+    type: float
+
+  seconds_between_github_writes:
+    type: float
+
+  secondary_rate_limit_wait_seconds:
+    type: float
+
+  json_file:
+    type: string
+
+  json_thousands_separator:
+    type: string
+
+  json_suite_details:
+    type: boolean
+
+  json_test_case_results:
+    type: boolean
+
+  search_pull_requests:
+    type: boolean
+
+outputs:
+  json:
+    type: string

--- a/linux/action-types.yml
+++ b/linux/action-types.yml
@@ -1,0 +1,173 @@
+# See https://github.com/typesafegithub/github-actions-typing/
+inputs:
+  github_token:
+    type: string
+
+  github_token_actor:
+    type: string
+
+  github_retries:
+    type: integer
+
+  ssl_verify:
+    type: boolean
+
+  commit:
+    type: string
+
+  check_name:
+    type: string
+
+  comment_title:
+    type: string
+
+  comment_mode:
+    type: enum
+    allowed-values:
+      - always
+      - changes
+      - changes in failures
+      - changes in errors
+      - failures
+      - errors
+      - off
+
+  fail_on:
+    type: enum
+    allowed-values:
+      - nothing
+      - errors
+      - test failures
+
+  action_fail:
+    type: boolean
+
+  action_fail_on_inconclusive:
+    type: boolean
+
+  files:
+    type: list
+    separator: '\n'
+    list-item:
+      type: string
+
+  junit_files:
+    type: list
+    separator: '\n'
+    list-item:
+      type: string
+
+  nunit_files:
+    type: list
+    separator: '\n'
+    list-item:
+      type: string
+
+  xunit_files:
+    type: list
+    separator: '\n'
+    list-item:
+      type: string
+
+  trx_files:
+    type: list
+    separator: '\n'
+    list-item:
+      type: string
+
+  time_unit:
+    type: enum
+    allowed-values:
+      - seconds
+      - milliseconds
+
+  test_file_prefix:
+    type: string
+
+  report_individual_runs:
+    type: boolean
+
+  report_suite_logs:
+    type: enum
+    allowed-values:
+      - info
+      - error
+      - any
+      - none
+
+  deduplicate_classes_by_file_name:
+    type: boolean
+
+  large_files:
+    type: boolean
+
+  ignore_runs:
+    type: boolean
+
+  check_run:
+    type: boolean
+
+  job_summary:
+    type: boolean
+
+  compare_to_earlier_commit:
+    type: boolean
+
+  pull_request_build:
+    type: enum
+    allowed-values:
+      - commit
+      - merge
+
+  event_file:
+    type: string
+
+  event_name:
+    type: string
+
+  test_changes_limit:
+    type: integer
+
+  check_run_annotations:
+    type: list
+    separator: ','
+    list-item:
+      type: enum
+      allowed-values:
+        - all tests
+        - skipped tests
+        - none
+
+  check_run_annotations_branch:
+    type: list
+    separator: ','
+    list-item:
+      type: string
+
+  seconds_between_github_reads:
+    type: float
+
+  seconds_between_github_writes:
+    type: float
+
+  secondary_rate_limit_wait_seconds:
+    type: float
+
+  json_file:
+    type: string
+
+  json_thousands_separator:
+    type: string
+
+  json_suite_details:
+    type: boolean
+
+  json_test_case_results:
+    type: boolean
+
+  search_pull_requests:
+    type: boolean
+
+outputs:
+  json:
+    type: string

--- a/macos/action-types.yml
+++ b/macos/action-types.yml
@@ -1,0 +1,173 @@
+# See https://github.com/typesafegithub/github-actions-typing/
+inputs:
+  github_token:
+    type: string
+
+  github_token_actor:
+    type: string
+
+  github_retries:
+    type: integer
+
+  ssl_verify:
+    type: boolean
+
+  commit:
+    type: string
+
+  check_name:
+    type: string
+
+  comment_title:
+    type: string
+
+  comment_mode:
+    type: enum
+    allowed-values:
+      - always
+      - changes
+      - changes in failures
+      - changes in errors
+      - failures
+      - errors
+      - off
+
+  fail_on:
+    type: enum
+    allowed-values:
+      - nothing
+      - errors
+      - test failures
+
+  action_fail:
+    type: boolean
+
+  action_fail_on_inconclusive:
+    type: boolean
+
+  files:
+    type: list
+    separator: '\n'
+    list-item:
+      type: string
+
+  junit_files:
+    type: list
+    separator: '\n'
+    list-item:
+      type: string
+
+  nunit_files:
+    type: list
+    separator: '\n'
+    list-item:
+      type: string
+
+  xunit_files:
+    type: list
+    separator: '\n'
+    list-item:
+      type: string
+
+  trx_files:
+    type: list
+    separator: '\n'
+    list-item:
+      type: string
+
+  time_unit:
+    type: enum
+    allowed-values:
+      - seconds
+      - milliseconds
+
+  test_file_prefix:
+    type: string
+
+  report_individual_runs:
+    type: boolean
+
+  report_suite_logs:
+    type: enum
+    allowed-values:
+      - info
+      - error
+      - any
+      - none
+
+  deduplicate_classes_by_file_name:
+    type: boolean
+
+  large_files:
+    type: boolean
+
+  ignore_runs:
+    type: boolean
+
+  check_run:
+    type: boolean
+
+  job_summary:
+    type: boolean
+
+  compare_to_earlier_commit:
+    type: boolean
+
+  pull_request_build:
+    type: enum
+    allowed-values:
+      - commit
+      - merge
+
+  event_file:
+    type: string
+
+  event_name:
+    type: string
+
+  test_changes_limit:
+    type: integer
+
+  check_run_annotations:
+    type: list
+    separator: ','
+    list-item:
+      type: enum
+      allowed-values:
+        - all tests
+        - skipped tests
+        - none
+
+  check_run_annotations_branch:
+    type: list
+    separator: ','
+    list-item:
+      type: string
+
+  seconds_between_github_reads:
+    type: float
+
+  seconds_between_github_writes:
+    type: float
+
+  secondary_rate_limit_wait_seconds:
+    type: float
+
+  json_file:
+    type: string
+
+  json_thousands_separator:
+    type: string
+
+  json_suite_details:
+    type: boolean
+
+  json_test_case_results:
+    type: boolean
+
+  search_pull_requests:
+    type: boolean
+
+outputs:
+  json:
+    type: string

--- a/python/test/test_action_yml.py
+++ b/python/test/test_action_yml.py
@@ -85,6 +85,38 @@ class TestActionYml(unittest.TestCase):
                 self.assertEqual(expected_hash, cache_hash, msg='Changing python/requirements.txt requires '
                                                                 'to update the MD5 hash in composite/action.yaml')
 
+    def test_action_types(self):
+        self.do_test_action_types('.')
+
+    def test_composite_action_types(self):
+        self.do_test_action_types('composite')
+
+    def test_linux_action_types(self):
+        self.do_test_action_types('linux')
+
+    def test_macos_action_types(self):
+        self.do_test_action_types('macos')
+
+    def test_windows_action_types(self):
+        self.do_test_action_types('windows')
+
+    def test_windows_bash_action_types(self):
+        self.do_test_action_types('windows/bash')
+
+    def do_test_action_types(self, subaction: str):
+        with open(project_root / 'action-types.yml', encoding='utf-8') as r:
+            root_action_types = yaml.safe_load(r)
+
+        with open(project_root / f'{subaction}/action.yml', encoding='utf-8') as r:
+            action = yaml.safe_load(r)
+
+        with open(project_root / f'{subaction}/action-types.yml', encoding='utf-8') as r:
+            action_types = yaml.safe_load(r)
+
+        self.assertEqual(action_types.get('inputs', {}).keys(), action.get('inputs', {}).keys())
+        self.assertEqual(action_types.get('outputs', {}).keys(), action.get('outputs', {}).keys())
+        self.assertEqual(action_types, root_action_types)
+
     def test_proxy_action(self):
         # TODO
         # run RUNNER_OS=Linux|Windows|macOS GITHUB_ACTION_PATH=... composite/proxy.sh

--- a/windows/action-types.yml
+++ b/windows/action-types.yml
@@ -1,0 +1,173 @@
+# See https://github.com/typesafegithub/github-actions-typing/
+inputs:
+  github_token:
+    type: string
+
+  github_token_actor:
+    type: string
+
+  github_retries:
+    type: integer
+
+  ssl_verify:
+    type: boolean
+
+  commit:
+    type: string
+
+  check_name:
+    type: string
+
+  comment_title:
+    type: string
+
+  comment_mode:
+    type: enum
+    allowed-values:
+      - always
+      - changes
+      - changes in failures
+      - changes in errors
+      - failures
+      - errors
+      - off
+
+  fail_on:
+    type: enum
+    allowed-values:
+      - nothing
+      - errors
+      - test failures
+
+  action_fail:
+    type: boolean
+
+  action_fail_on_inconclusive:
+    type: boolean
+
+  files:
+    type: list
+    separator: '\n'
+    list-item:
+      type: string
+
+  junit_files:
+    type: list
+    separator: '\n'
+    list-item:
+      type: string
+
+  nunit_files:
+    type: list
+    separator: '\n'
+    list-item:
+      type: string
+
+  xunit_files:
+    type: list
+    separator: '\n'
+    list-item:
+      type: string
+
+  trx_files:
+    type: list
+    separator: '\n'
+    list-item:
+      type: string
+
+  time_unit:
+    type: enum
+    allowed-values:
+      - seconds
+      - milliseconds
+
+  test_file_prefix:
+    type: string
+
+  report_individual_runs:
+    type: boolean
+
+  report_suite_logs:
+    type: enum
+    allowed-values:
+      - info
+      - error
+      - any
+      - none
+
+  deduplicate_classes_by_file_name:
+    type: boolean
+
+  large_files:
+    type: boolean
+
+  ignore_runs:
+    type: boolean
+
+  check_run:
+    type: boolean
+
+  job_summary:
+    type: boolean
+
+  compare_to_earlier_commit:
+    type: boolean
+
+  pull_request_build:
+    type: enum
+    allowed-values:
+      - commit
+      - merge
+
+  event_file:
+    type: string
+
+  event_name:
+    type: string
+
+  test_changes_limit:
+    type: integer
+
+  check_run_annotations:
+    type: list
+    separator: ','
+    list-item:
+      type: enum
+      allowed-values:
+        - all tests
+        - skipped tests
+        - none
+
+  check_run_annotations_branch:
+    type: list
+    separator: ','
+    list-item:
+      type: string
+
+  seconds_between_github_reads:
+    type: float
+
+  seconds_between_github_writes:
+    type: float
+
+  secondary_rate_limit_wait_seconds:
+    type: float
+
+  json_file:
+    type: string
+
+  json_thousands_separator:
+    type: string
+
+  json_suite_details:
+    type: boolean
+
+  json_test_case_results:
+    type: boolean
+
+  search_pull_requests:
+    type: boolean
+
+outputs:
+  json:
+    type: string

--- a/windows/bash/action-types.yml
+++ b/windows/bash/action-types.yml
@@ -1,0 +1,173 @@
+# See https://github.com/typesafegithub/github-actions-typing/
+inputs:
+  github_token:
+    type: string
+
+  github_token_actor:
+    type: string
+
+  github_retries:
+    type: integer
+
+  ssl_verify:
+    type: boolean
+
+  commit:
+    type: string
+
+  check_name:
+    type: string
+
+  comment_title:
+    type: string
+
+  comment_mode:
+    type: enum
+    allowed-values:
+      - always
+      - changes
+      - changes in failures
+      - changes in errors
+      - failures
+      - errors
+      - off
+
+  fail_on:
+    type: enum
+    allowed-values:
+      - nothing
+      - errors
+      - test failures
+
+  action_fail:
+    type: boolean
+
+  action_fail_on_inconclusive:
+    type: boolean
+
+  files:
+    type: list
+    separator: '\n'
+    list-item:
+      type: string
+
+  junit_files:
+    type: list
+    separator: '\n'
+    list-item:
+      type: string
+
+  nunit_files:
+    type: list
+    separator: '\n'
+    list-item:
+      type: string
+
+  xunit_files:
+    type: list
+    separator: '\n'
+    list-item:
+      type: string
+
+  trx_files:
+    type: list
+    separator: '\n'
+    list-item:
+      type: string
+
+  time_unit:
+    type: enum
+    allowed-values:
+      - seconds
+      - milliseconds
+
+  test_file_prefix:
+    type: string
+
+  report_individual_runs:
+    type: boolean
+
+  report_suite_logs:
+    type: enum
+    allowed-values:
+      - info
+      - error
+      - any
+      - none
+
+  deduplicate_classes_by_file_name:
+    type: boolean
+
+  large_files:
+    type: boolean
+
+  ignore_runs:
+    type: boolean
+
+  check_run:
+    type: boolean
+
+  job_summary:
+    type: boolean
+
+  compare_to_earlier_commit:
+    type: boolean
+
+  pull_request_build:
+    type: enum
+    allowed-values:
+      - commit
+      - merge
+
+  event_file:
+    type: string
+
+  event_name:
+    type: string
+
+  test_changes_limit:
+    type: integer
+
+  check_run_annotations:
+    type: list
+    separator: ','
+    list-item:
+      type: enum
+      allowed-values:
+        - all tests
+        - skipped tests
+        - none
+
+  check_run_annotations_branch:
+    type: list
+    separator: ','
+    list-item:
+      type: string
+
+  seconds_between_github_reads:
+    type: float
+
+  seconds_between_github_writes:
+    type: float
+
+  secondary_rate_limit_wait_seconds:
+    type: float
+
+  json_file:
+    type: string
+
+  json_thousands_separator:
+    type: string
+
+  json_suite_details:
+    type: boolean
+
+  json_test_case_results:
+    type: boolean
+
+  search_pull_requests:
+    type: boolean
+
+outputs:
+  json:
+    type: string


### PR DESCRIPTION
I would like to see your action first-class supported by https://github.com/typesafegithub/github-workflows-kt, a Kotlin DSL to write GitHub Action workflows.

The project came up with ways to reduce operational load when keeping the library's action wrappers in sync with actions' inputs and outputs.
The solutions include onboarding https://github.com/typesafegithub/github-actions-typing.
It is as easy as adding an extra YAML file to your repository root, and (optionally) adding a simple GitHub workflow that validates this new file.
Thanks to this, the code generator in the Kotlin DSL can fetch typing info provided by you instead of them, which has a number of benefits.
It has no negative effects on current action consumers, they continue to use the action via regular GitHub API, as if the file was not there.

In this pull request, I would like to ask you if you are open to introduce such typings in your action and also provide the current state as far as I could determine it.
You would not be the first, there are already other actions using it, like e.g. my https://github.com/Vampire/setup-wsl or also Microsoft's https://github.com/microsoft/setup-msbuild.

Also "regular" users can benefit from this clear and formalized typing definition, seeing exactly what values are valid.
And as the typings are made independent from the Kotlin DSL library, also other DSL or similar consumers could use these typings in the future.

When accepting this PR and in the future maintaining the typing yourself,
please keep in mind that API are generated from these typing information.
So if you for example recognize that a type is wrong and want to change it for example from `string` to `integer`,
this would be a breaking change for such consumers and should therefore be done with a major version bump.
Backwards compatible changes like new enum options, or new inputs or outputs can of course be released in a minor version as usual.

After hopefully merging this PR it would be nice if you could cut a release soon,
so that the shiny new typings can be used right away.

