### PR TITLE
Allow disabling the pip cache task

### DIFF
--- a/composite/action.yml
+++ b/composite/action.yml
@@ -223,7 +223,7 @@ runs:
 
     - name: Restore PIP packages cache
       uses: actions/cache/restore@v4
-      if: success() && inputs.use_pip_cache
+      if: success() && inputs.use_pip_cache == 'true'
       id: cache
       continue-on-error: true
       with:
@@ -340,7 +340,7 @@ runs:
 
     - name: Save PIP packages cache
       uses: actions/cache/save@v4
-      if: ( success() || failure() ) && ! steps.cache.outputs.cache-hit && inputs.use_pip_cache
+      if: ( success() || failure() ) && ! steps.cache.outputs.cache-hit && inputs.use_pip_cache == 'true'
       continue-on-error: true
       with:
         path: ${{ steps.os.outputs.pip-cache }}

--- a/composite/action.yml
+++ b/composite/action.yml
@@ -146,6 +146,10 @@ inputs:
     description: 'Prior to v2.6.0, the action used the "/search/issues" REST API to find pull requests related to a commit. If you need to restore that behaviour, set this to "true". Defaults to "false".'
     default: 'false'
     required: false
+  use_pip_cache:
+    description: 'Use the pip cache task, for self-hosted runners with persistent storage you might want to disbale this.'
+    default: 'true'
+    required: false
 
 outputs:
   json:
@@ -219,6 +223,7 @@ runs:
 
     - name: Restore PIP packages cache
       uses: actions/cache/restore@v4
+      if: success() && inputs.use_pip_cache
       id: cache
       continue-on-error: true
       with:
@@ -335,7 +340,7 @@ runs:
 
     - name: Save PIP packages cache
       uses: actions/cache/save@v4
-      if: ( success() || failure() ) && ! steps.cache.outputs.cache-hit
+      if: ( success() || failure() ) && ! steps.cache.outputs.cache-hit && inputs.use_pip_cache
       continue-on-error: true
       with:
         path: ${{ steps.os.outputs.pip-cache }}

--- a/linux/action.yml
+++ b/linux/action.yml
@@ -146,6 +146,10 @@ inputs:
     description: 'Prior to v2.6.0, the action used the "/search/issues" REST API to find pull requests related to a commit. If you need to restore that behaviour, set this to "true". Defaults to "false".'
     default: 'false'
     required: false
+  use_pip_cache:
+    description: 'Use the pip cache task, for self-hosted runners with persistent storage you might want to disbale this.'
+    default: 'true'
+    required: false
 
 outputs:
   json:
@@ -195,6 +199,7 @@ runs:
 
     - name: Restore PIP packages cache
       uses: actions/cache/restore@v4
+      if: success() && inputs.use_pip_cache
       id: cache
       continue-on-error: true
       with:
@@ -300,7 +305,7 @@ runs:
 
     - name: Save PIP packages cache
       uses: actions/cache/save@v4
-      if: ( success() || failure() ) && ! steps.cache.outputs.cache-hit
+      if: ( success() || failure() ) && ! steps.cache.outputs.cache-hit && inputs.use_pip_cache
       continue-on-error: true
       with:
         path: '~/.cache/pip'

--- a/linux/action.yml
+++ b/linux/action.yml
@@ -199,7 +199,7 @@ runs:
 
     - name: Restore PIP packages cache
       uses: actions/cache/restore@v4
-      if: success() && inputs.use_pip_cache
+      if: success() && inputs.use_pip_cache == 'true'
       id: cache
       continue-on-error: true
       with:
@@ -305,7 +305,7 @@ runs:
 
     - name: Save PIP packages cache
       uses: actions/cache/save@v4
-      if: ( success() || failure() ) && ! steps.cache.outputs.cache-hit && inputs.use_pip_cache
+      if: ( success() || failure() ) && ! steps.cache.outputs.cache-hit && inputs.use_pip_cache == 'true'
       continue-on-error: true
       with:
         path: '~/.cache/pip'

--- a/macos/action.yml
+++ b/macos/action.yml
@@ -146,6 +146,10 @@ inputs:
     description: 'Prior to v2.6.0, the action used the "/search/issues" REST API to find pull requests related to a commit. If you need to restore that behaviour, set this to "true". Defaults to "false".'
     default: 'false'
     required: false
+  use_pip_cache:
+    description: 'Use the pip cache task, for self-hosted runners with persistent storage you might want to disbale this.'
+    default: 'true'
+    required: false
 
 outputs:
   json:
@@ -195,6 +199,7 @@ runs:
 
     - name: Restore PIP packages cache
       uses: actions/cache/restore@v4
+      if: success() && inputs.use_pip_cache
       id: cache
       continue-on-error: true
       with:
@@ -300,7 +305,7 @@ runs:
 
     - name: Save PIP packages cache
       uses: actions/cache/save@v4
-      if: ( success() || failure() ) && ! steps.cache.outputs.cache-hit
+      if: ( success() || failure() ) && ! steps.cache.outputs.cache-hit && inputs.use_pip_cache
       continue-on-error: true
       with:
         path: '~/Library/Caches/pip'

--- a/macos/action.yml
+++ b/macos/action.yml
@@ -199,7 +199,7 @@ runs:
 
     - name: Restore PIP packages cache
       uses: actions/cache/restore@v4
-      if: success() && inputs.use_pip_cache
+      if: success() && inputs.use_pip_cache == 'true'
       id: cache
       continue-on-error: true
       with:
@@ -305,7 +305,7 @@ runs:
 
     - name: Save PIP packages cache
       uses: actions/cache/save@v4
-      if: ( success() || failure() ) && ! steps.cache.outputs.cache-hit && inputs.use_pip_cache
+      if: ( success() || failure() ) && ! steps.cache.outputs.cache-hit && inputs.use_pip_cache == 'true'
       continue-on-error: true
       with:
         path: '~/Library/Caches/pip'

--- a/windows/action.yml
+++ b/windows/action.yml
@@ -146,6 +146,10 @@ inputs:
     description: 'Prior to v2.6.0, the action used the "/search/issues" REST API to find pull requests related to a commit. If you need to restore that behaviour, set this to "true". Defaults to "false".'
     default: 'false'
     required: false
+  use_pip_cache:
+    description: 'Use the pip cache task, for self-hosted runners with persistent storage you might want to disbale this.'
+    default: 'true'
+    required: false
 
 outputs:
   json:
@@ -195,6 +199,7 @@ runs:
 
     - name: Restore PIP packages cache
       uses: actions/cache/restore@v4
+      if: success() && inputs.use_pip_cache
       id: cache
       continue-on-error: true
       with:
@@ -306,7 +311,7 @@ runs:
 
     - name: Save PIP packages cache
       uses: actions/cache/save@v4
-      if: ( success() || failure() ) && ! steps.cache.outputs.cache-hit
+      if: ( success() || failure() ) && ! steps.cache.outputs.cache-hit && inputs.use_pip_cache
       continue-on-error: true
       with:
         path: '~\AppData\Local\pip\Cache'

--- a/windows/action.yml
+++ b/windows/action.yml
@@ -199,7 +199,7 @@ runs:
 
     - name: Restore PIP packages cache
       uses: actions/cache/restore@v4
-      if: success() && inputs.use_pip_cache
+      if: success() && inputs.use_pip_cache == 'true'
       id: cache
       continue-on-error: true
       with:
@@ -311,7 +311,7 @@ runs:
 
     - name: Save PIP packages cache
       uses: actions/cache/save@v4
-      if: ( success() || failure() ) && ! steps.cache.outputs.cache-hit && inputs.use_pip_cache
+      if: ( success() || failure() ) && ! steps.cache.outputs.cache-hit && inputs.use_pip_cache == 'true'
       continue-on-error: true
       with:
         path: '~\AppData\Local\pip\Cache'

--- a/windows/bash/action.yml
+++ b/windows/bash/action.yml
@@ -146,6 +146,10 @@ inputs:
     description: 'Prior to v2.6.0, the action used the "/search/issues" REST API to find pull requests related to a commit. If you need to restore that behaviour, set this to "true". Defaults to "false".'
     default: 'false'
     required: false
+  use_pip_cache:
+    description: 'Use the pip cache task, for self-hosted runners with persistent storage you might want to disbale this.'
+    default: 'true'
+    required: false
 
 outputs:
   json:
@@ -195,6 +199,7 @@ runs:
 
     - name: Restore PIP packages cache
       uses: actions/cache/restore@v4
+      if: success() && inputs.use_pip_cache
       id: cache
       continue-on-error: true
       with:
@@ -304,7 +309,7 @@ runs:
 
     - name: Save PIP packages cache
       uses: actions/cache/save@v4
-      if: ( success() || failure() ) && ! steps.cache.outputs.cache-hit
+      if: ( success() || failure() ) && ! steps.cache.outputs.cache-hit && inputs.use_pip_cache
       continue-on-error: true
       with:
         path: '~\AppData\Local\pip\Cache'

--- a/windows/bash/action.yml
+++ b/windows/bash/action.yml
@@ -199,7 +199,7 @@ runs:
 
     - name: Restore PIP packages cache
       uses: actions/cache/restore@v4
-      if: success() && inputs.use_pip_cache
+      if: success() && inputs.use_pip_cache == 'true'
       id: cache
       continue-on-error: true
       with:
@@ -309,7 +309,7 @@ runs:
 
     - name: Save PIP packages cache
       uses: actions/cache/save@v4
-      if: ( success() || failure() ) && ! steps.cache.outputs.cache-hit && inputs.use_pip_cache
+      if: ( success() || failure() ) && ! steps.cache.outputs.cache-hit && inputs.use_pip_cache == 'true'
       continue-on-error: true
       with:
         path: '~\AppData\Local\pip\Cache'


### PR DESCRIPTION
This helps a lot when you have reused and persistent self-hosted runners. The pip cache dir gets to be enourmous after a while slowing down this task.