### PR TITLE
Resolve regex library warnings

### DIFF
--- a/python/test/test_junit.py
+++ b/python/test/test_junit.py
@@ -221,7 +221,7 @@ class JUnitXmlParseTest:
     def prettify_exception(exception) -> str:
         exception = exception.__repr__()
         exception = re.sub(r'\r?\n\r?', r'\\n', exception)
-        exception = re.sub(r'\(', ': ', exception, 1)
+        exception = re.sub(r'\(', ': ', exception, count=1)
         exception = re.sub(r'file:.*/', '', exception)
         exception = re.sub(r',?\s*\)\)$', ')', exception)
         return exception


### PR DESCRIPTION
# PR Summary
This small PR resolves the regex library warnings:
```python
python/test/test_junit.py:224: DeprecationWarning: 'count' is passed as positional argument
```