### PR TITLE
Fix test name comparison for names containing newlines

### DIFF
--- a/python/publish/__init__.py
+++ b/python/publish/__init__.py
@@ -942,12 +942,32 @@ def get_skipped_tests_list_annotation(cases: UnitTestCaseResults, max_chunk_size
     return get_test_list_annotation(restrict_unicode_list(get_skipped_tests_list(cases)), 'skipped test', max_chunk_size)
 
 
+# Separator between test names in annotation raw_details.
+# Uses a Unicode Private Use Area character (U+E000) followed by a newline so that:
+# - splitting on this separator preserves literal newlines inside test names
+# - the newline keeps one-test-per-line readability in the GitHub "Raw output" UI
+# - U+E000 cannot appear in test names from any test framework
+# Old annotations used plain '\n'; the reader detects the format by checking for U+E000.
+test_list_separator = '\ue000\n'
+
+
+def deserialize_test_names(raw_details: str) -> List[str]:
+    """Deserialize test names from raw_details, handling both old and new formats.
+
+    New format: test names separated by U+E000 + newline.
+    Old format: test names separated by plain newline.
+    """
+    if '\ue000' in raw_details:
+        return raw_details.split(test_list_separator)
+    return raw_details.split('\n')
+
+
 def get_test_list_annotation(tests: List[str], label: str, max_chunk_size: int = 64000) -> List[Annotation]:
     if len(tests) == 0:
         return []
 
     # the max_chunk_size must not be larger than the abbreviate_bytes limit in Annotation.to_dict
-    test_chunks = chunk_test_list(sorted(tests), '\n', max_chunk_size)
+    test_chunks = chunk_test_list(sorted(tests), test_list_separator, max_chunk_size)
 
     if len(test_chunks) == 1:
         if len(tests) == 1:
@@ -957,7 +977,7 @@ def get_test_list_annotation(tests: List[str], label: str, max_chunk_size: int =
             title = f'{len(tests)} {label}s found'
             message = f'There are {len(tests)} {label}s, see "Raw output" for the full list of {label}s.'
 
-        return [create_tests_list_annotation(title=title, message=message, raw_details='\n'.join(test_chunks[0]))]
+        return [create_tests_list_annotation(title=title, message=message, raw_details=test_list_separator.join(test_chunks[0]))]
 
     first = 1
     annotations = []
@@ -965,7 +985,7 @@ def get_test_list_annotation(tests: List[str], label: str, max_chunk_size: int =
         last = first + len(chunk) - 1
         title = f'{len(tests)} {label}s found (test {first} to {last})'
         message = f'There are {len(tests)} {label}s, see "Raw output" for the list of {label}s {first} to {last}.'
-        annotation = create_tests_list_annotation(title=title, message=message, raw_details='\n'.join(chunk))
+        annotation = create_tests_list_annotation(title=title, message=message, raw_details=test_list_separator.join(chunk))
         annotations.append(annotation)
         first = last + 1
 

--- a/python/publish/publisher.py
+++ b/python/publish/publisher.py
@@ -22,7 +22,7 @@ from publish import __version__, get_json_path, comment_mode_off, digest_prefix,
     get_long_summary_with_digest_md, get_error_annotations, get_case_annotations, get_suite_annotations, \
     get_all_tests_list_annotation, get_skipped_tests_list_annotation, get_all_tests_list, \
     get_skipped_tests_list, all_tests_list, skipped_tests_list, pull_request_build_mode_merge, \
-    Annotation, SomeTestChanges
+    Annotation, SomeTestChanges, deserialize_test_names
 from publish import logger
 from publish.github_action import GithubAction
 from publish.unittestresults import UnitTestCaseResults, UnitTestRunResults, UnitTestRunDeltaResults, \
@@ -407,7 +407,7 @@ class Publisher:
     def get_test_list_from_annotation(annotation: CheckRunAnnotation) -> Optional[List[str]]:
         if annotation is None or not annotation.raw_details:
             return None
-        return annotation.raw_details.split('\n')
+        return deserialize_test_names(annotation.raw_details)
 
     def get_publish_data(self,
                          stats: UnitTestRunResults,

--- a/python/test/test_publish.py
+++ b/python/test/test_publish.py
@@ -14,7 +14,7 @@ from publish import Annotation, UnitTestSuite, UnitTestRunResults, UnitTestRunDe
     get_long_summary_without_runs_md,  get_long_summary_with_digest_md, get_test_changes_md, get_test_changes_list_md,  \
     get_test_changes_summary_md, get_case_annotations, get_case_annotation, get_suite_annotations, \
     get_suite_annotations_for_suite, get_all_tests_list_annotation, get_skipped_tests_list_annotation, get_case_messages, \
-    chunk_test_list, message_is_contained_in_content
+    chunk_test_list, message_is_contained_in_content, test_list_separator, deserialize_test_names
 from publish.junit import parse_junit_xml_files, process_junit_xml_elems
 from publish.unittestresults import get_stats, UnitTestCase, ParseError, get_test_results, create_unit_test_case_results
 from test_utils import temp_locale, d, n
@@ -1916,7 +1916,7 @@ class PublishTest(unittest.TestCase):
         })
 
         self.assertEqual([], get_all_tests_list_annotation(create_unit_test_case_results()))
-        self.assertEqual([Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There are 3 tests, see "Raw output" for the full list of tests.', title='3 tests found', raw_details='class1 ‑ test1\nclass1 ‑ test2\nfile ‑ class1 ‑ test2')], get_all_tests_list_annotation(results))
+        self.assertEqual([Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There are 3 tests, see "Raw output" for the full list of tests.', title='3 tests found', raw_details='class1 ‑ test1\ue000\nclass1 ‑ test2\ue000\nfile ‑ class1 ‑ test2')], get_all_tests_list_annotation(results))
         del results[(None, 'class1', 'test1')]
         del results[('file', 'class1', 'test2')]
         self.assertEqual([Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There is 1 test, see "Raw output" for the name of the test.', title='1 test found', raw_details='class1 ‑ test2')], get_all_tests_list_annotation(results))
@@ -1946,10 +1946,10 @@ class PublishTest(unittest.TestCase):
         self.assertEqual([], get_all_tests_list_annotation(create_unit_test_case_results()))
         self.assertEqual(
             [
-                Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There are 3 tests, see "Raw output" for the list of tests 1 to 2.', title='3 tests found (test 1 to 2)', raw_details='class1 ‑ test1\nclass1 ‑ test2'),
+                Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There are 3 tests, see "Raw output" for the list of tests 1 to 2.', title='3 tests found (test 1 to 2)', raw_details='class1 ‑ test1\ue000\nclass1 ‑ test2'),
                 Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There are 3 tests, see "Raw output" for the list of tests 3 to 3.', title='3 tests found (test 3 to 3)', raw_details='file ‑ class1 ‑ test2')
             ],
-            get_all_tests_list_annotation(results, max_chunk_size=40)
+            get_all_tests_list_annotation(results, max_chunk_size=43)
         )
 
     def test_get_skipped_tests_list_annotation(self):
@@ -1977,7 +1977,7 @@ class PublishTest(unittest.TestCase):
         self.assertEqual([], get_skipped_tests_list_annotation(create_unit_test_case_results()))
         self.assertEqual([Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There is 1 skipped test, see "Raw output" for the name of the skipped test.', title='1 skipped test found', raw_details='class1 ‑ test2')], get_skipped_tests_list_annotation(results))
         del results[(None, 'class1', 'test1')]['success']
-        self.assertEqual([Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There are 2 skipped tests, see "Raw output" for the full list of skipped tests.', title='2 skipped tests found', raw_details='class1 ‑ test1\nclass1 ‑ test2')], get_skipped_tests_list_annotation(results))
+        self.assertEqual([Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There are 2 skipped tests, see "Raw output" for the full list of skipped tests.', title='2 skipped tests found', raw_details='class1 ‑ test1\ue000\nclass1 ‑ test2')], get_skipped_tests_list_annotation(results))
 
     def test_get_skipped_tests_list_annotation_chunked(self):
         results = create_unit_test_case_results({
@@ -2001,10 +2001,10 @@ class PublishTest(unittest.TestCase):
         self.assertEqual([], get_skipped_tests_list_annotation(create_unit_test_case_results()))
         self.assertEqual(
             [
-                Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There are 3 skipped tests, see "Raw output" for the list of skipped tests 1 to 2.', title='3 skipped tests found (test 1 to 2)', raw_details='class1 ‑ test1\nclass1 ‑ test2'),
+                Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There are 3 skipped tests, see "Raw output" for the list of skipped tests 1 to 2.', title='3 skipped tests found (test 1 to 2)', raw_details='class1 ‑ test1\ue000\nclass1 ‑ test2'),
                 Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There are 3 skipped tests, see "Raw output" for the list of skipped tests 3 to 3.', title='3 skipped tests found (test 3 to 3)', raw_details='file ‑ class1 ‑ test2')
             ],
-            get_skipped_tests_list_annotation(results, max_chunk_size=40)
+            get_skipped_tests_list_annotation(results, max_chunk_size=43)
         )
 
     def test_chunk(self):
@@ -2172,6 +2172,48 @@ class PublishTest(unittest.TestCase):
                                  ('the  message', '\tthe message in the content')]:
             with self.subTest(message=message, content=content):
                 self.assertTrue(message_is_contained_in_content(message, content))
+
+
+    def test_get_all_tests_list_annotation_with_newline_in_name(self):
+        results = create_unit_test_case_results({
+            (None, 'class1', 'normal test'): {
+                'success': [
+                    UnitTestCase(result_file='result-file1', test_file='file1', line=123, class_name='class1', test_name='normal test', result='success', message=None, content=None, stdout=None, stderr=None, time=1.0)
+                ],
+            },
+            (None, 'class1', 'test with\nnewline'): {
+                'success': [
+                    UnitTestCase(result_file='result-file1', test_file='file1', line=123, class_name='class1', test_name='test with\nnewline', result='success', message=None, content=None, stdout=None, stderr=None, time=1.0)
+                ],
+            },
+        })
+
+        annotations = get_all_tests_list_annotation(results)
+        self.assertEqual(1, len(annotations))
+        # newline in test name is preserved verbatim; separator is U+E000 + newline
+        self.assertEqual('class1 ‑ normal test\ue000\nclass1 ‑ test with\nnewline', annotations[0].raw_details)
+
+    def test_deserialize_new_format(self):
+        raw = 'class ‑ test with\nnewline\ue000\nclass ‑ normal'
+        self.assertEqual(['class ‑ test with\nnewline', 'class ‑ normal'], deserialize_test_names(raw))
+
+    def test_deserialize_old_format(self):
+        # Old format without U+E000: plain split on newline
+        raw = 'class ‑ test1\nclass ‑ test2'
+        self.assertEqual(['class ‑ test1', 'class ‑ test2'], deserialize_test_names(raw))
+
+    def test_deserialize_old_format_with_backslash_n(self):
+        # Old annotation with a test name containing literal backslash-n (two chars).
+        # Must NOT be corrupted -- plain split preserves it as-is.
+        raw = 'class ‑ test\\npath\nclass ‑ other'
+        result = deserialize_test_names(raw)
+        self.assertEqual(['class ‑ test\\npath', 'class ‑ other'], result)
+
+    def test_deserialize_old_format_with_restrict_unicode(self):
+        # Old annotation with restrict_unicode output (backslash-U sequences)
+        raw = 'class ‑ test \\U0001d483\nclass ‑ test \\U0001d484'
+        result = deserialize_test_names(raw)
+        self.assertEqual(['class ‑ test \\U0001d483', 'class ‑ test \\U0001d484'], result)
 
 
 if __name__ == '__main__':

--- a/python/test/test_publisher.py
+++ b/python/test/test_publisher.py
@@ -353,11 +353,11 @@ class TestPublisher(unittest.TestCase):
         settings = self.create_settings(check_run_annotation=[all_tests_list, skipped_tests_list])
         gh = mock.MagicMock()
         publisher = Publisher(settings, gh, None)
-        annotations = publisher.get_test_list_annotations(cases, max_chunk_size=42)
+        annotations = publisher.get_test_list_annotations(cases, max_chunk_size=48)
 
         self.assertEqual([
-            Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There are 2 skipped tests, see "Raw output" for the full list of skipped tests.', title='2 skipped tests found', raw_details='class ‑ test efgh\nclass ‑ test ijkl'),
-            Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There are 3 tests, see "Raw output" for the list of tests 1 to 2.', title='3 tests found (test 1 to 2)', raw_details='class ‑ test abcd\nclass ‑ test efgh'),
+            Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There are 2 skipped tests, see "Raw output" for the full list of skipped tests.', title='2 skipped tests found', raw_details='class ‑ test efgh\ue000\nclass ‑ test ijkl'),
+            Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There are 3 tests, see "Raw output" for the list of tests 1 to 2.', title='3 tests found (test 1 to 2)', raw_details='class ‑ test abcd\ue000\nclass ‑ test efgh'),
             Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There are 3 tests, see "Raw output" for the list of tests 3 to 3.', title='3 tests found (test 3 to 3)', raw_details='class ‑ test ijkl')
         ], annotations)
 
@@ -371,7 +371,7 @@ class TestPublisher(unittest.TestCase):
         settings = self.create_settings(check_run_annotation=[all_tests_list, skipped_tests_list])
         gh = mock.MagicMock()
         publisher = Publisher(settings, gh, None)
-        annotations = publisher.get_test_list_annotations(cases, max_chunk_size=42)
+        annotations = publisher.get_test_list_annotations(cases, max_chunk_size=48)
 
         self.assertEqual([
             Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There are 2 skipped tests, see "Raw output" for the list of skipped tests 1 to 1.', title='2 skipped tests found (test 1 to 1)', raw_details='class ‑ test \\U0001d483'),
@@ -1445,7 +1445,7 @@ class TestPublisher(unittest.TestCase):
             ] if skipped_tests_list in annotations else []
         ) + (
             [
-                Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There are 3 tests, see "Raw output" for the full list of tests.', title='3 tests found', raw_details='class ‑ test\nclass ‑ test2\nclass ‑ test3')
+                Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There are 3 tests, see "Raw output" for the full list of tests.', title='3 tests found', raw_details='class ‑ test\ue000\nclass ‑ test2\ue000\nclass ‑ test3')
             ] if all_tests_list in annotations else []
         )
 
@@ -1584,7 +1584,7 @@ class TestPublisher(unittest.TestCase):
                 Annotation(path='test file', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='warning', message='result file [took 1s]', title='1 out of 2 runs failed: test (class)', raw_details='message\ncontent\nstdout\nstderr'),
                 Annotation(path='test file', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='failure', message='result file [took 1s]', title='1 out of 2 runs with error: test2 (class)', raw_details='error message\nerror content\nerror stdout\nerror stderr'),
                 Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There is 1 skipped test, see "Raw output" for the name of the skipped test.', title='1 skipped test found', raw_details='class ‑ test3'),
-                Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There are 3 tests, see "Raw output" for the full list of tests.', title='3 tests found', raw_details='class ‑ test\nclass ‑ test2\nclass ‑ test3'),
+                Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There are 3 tests, see "Raw output" for the full list of tests.', title='3 tests found', raw_details='class ‑ test\ue000\nclass ‑ test2\ue000\nclass ‑ test3'),
             ],
             check_url=None,
             cases=self.cases,
@@ -1688,7 +1688,7 @@ class TestPublisher(unittest.TestCase):
                 Annotation(path='test file', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='warning', message='result file [took 1s]', title='1 out of 2 runs failed: test (class)', raw_details='message\ncontent\nstdout\nstderr'),
                 Annotation(path='test file', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='failure', message='result file [took 1s]', title='1 out of 2 runs with error: test2 (class)', raw_details='error message\nerror content\nerror stdout\nerror stderr'),
                 Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There is 1 skipped test, see "Raw output" for the name of the skipped test.', title='1 skipped test found', raw_details='class ‑ test3'),
-                Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There are 3 tests, see "Raw output" for the full list of tests.', title='3 tests found', raw_details='class ‑ test\nclass ‑ test2\nclass ‑ test3'),
+                Annotation(path='.github', start_line=0, end_line=0, start_column=None, end_column=None, annotation_level='notice', message='There are 3 tests, see "Raw output" for the full list of tests.', title='3 tests found', raw_details='class ‑ test\ue000\nclass ‑ test2\ue000\nclass ‑ test3'),
             ]
             expected = PublishData(
                 title=f"7 errors, 6 fail, 5 skipped, 4 pass in 57m 36s",


### PR DESCRIPTION
## Problem

Parameterized tests (e.g. JUnit 5 `@ValueSource` with multi-line strings, or `@CsvSource` with embedded `\n`) produce test names containing literal newline characters in the JUnit XML `<testcase name="...">` attribute.

These names are serialized into check run annotations by joining with `'\n'` (`get_test_list_annotation`) and deserialized by splitting on `'\n'` (`get_test_list_from_annotation`). When a test name itself contains a newline, the split produces phantom fragments that don't match real test names, causing spurious "removes X and adds Y tests" counts in PR comments -- even when no tests actually changed.

## Solution

Replace the plain `'\n'` delimiter between test names with U+E000 (Unicode Private Use Area character) followed by `'\n'`. The PUA character acts as an unambiguous boundary marker:

- No test framework, language, or build tool generates PUA characters in test names -- while not strictly impossible, a test name containing U+E000 would require a deliberate choice by the developer. This is the same class of assumption the original code made about `'\n'` not appearing in test names, but substantially safer in practice.
- It survives the GitHub Check Runs API roundtrip (verified against the real annotations API)
- The trailing `'\n'` preserves one-test-per-line readability in the GitHub "Raw output" UI
- No escaping/unescaping logic is needed -- test names are stored verbatim

On read, the presence of U+E000 signals the new format; its absence triggers a plain `'\n'` split for full backwards compatibility with existing annotations. Old annotations are read exactly as before -- no transformation is applied to them, so there is zero risk of corrupting old data containing literal `\n` or `\\` sequences.

### Changes

- `python/publish/__init__.py`: Added `test_list_separator` (U+E000 + newline), `deserialize_test_names()`, and updated `get_test_list_annotation()` to use the new separator
- `python/publish/publisher.py`: `get_test_list_from_annotation()` now uses `deserialize_test_names()` instead of a plain `split('\n')`
- Tests: Updated expected `raw_details` values, added tests for newline-in-test-name serialization, new/old format deserialization, and backwards compatibility with old annotations containing `\n` and `\U` literal sequences