### PR TITLE
fix: prevent CMD_EXEC injection via env indirection for user-controll…

### DIFF
--- a/docker/action.yml
+++ b/docker/action.yml
@@ -220,9 +220,13 @@ runs:
         INPUT_LOG_LEVEL: ${{ inputs.log_level }}
         # not documented
         INPUT_ROOT_LOG_LEVEL: ${{ inputs.root_log_level }}
+        DOCKER_PLATFORM: ${{ inputs.docker_platform }}
+        DOCKER_REGISTRY: ${{ inputs.docker_registry }}
+        DOCKER_IMAGE: ${{ inputs.docker_image }}
+        DOCKER_TAG: ${{ inputs.docker_tag }}
       run: |
         # Publish Test Results
-        platform="${{ inputs.docker_platform }}"
+        platform="$DOCKER_PLATFORM"
         docker run ${platform:+--platform $platform} \
           --workdir "/github/workspace" \
           --rm \
@@ -314,7 +318,7 @@ runs:
           -v "/var/run/docker.sock":"/var/run/docker.sock" \
           -v "/home/runner/work/_temp/_github_home":"/github/home" \
           -v "$GITHUB_WORKSPACE":"/github/workspace" \
-          ${{ inputs.docker_registry }}/${{ inputs.docker_image }}:${{ inputs.docker_tag }}
+          $DOCKER_REGISTRY/$DOCKER_IMAGE:$DOCKER_TAG
       shell: bash
 
 branding:

--- a/misc/action/find-workflows/action.yml
+++ b/misc/action/find-workflows/action.yml
@@ -33,9 +33,11 @@ runs:
       id: workflows
       env:
         GITHUB_TOKEN: ${{ github.token }}
+        SCRIPT_URL: ${{ inputs.url }}
+        SCRIPT_QUERY: ${{ inputs.query }}
       shell: bash
       run: |
-        python ${{ github.action_path }}/script.py ${{ inputs.url }} ${{ inputs.query }}
+        python "${{ github.action_path }}/script.py" "$SCRIPT_URL" "$SCRIPT_QUERY"
 
 branding:
   icon: 'download-cloud'

--- a/misc/action/json-output/action.yml
+++ b/misc/action/json-output/action.yml
@@ -38,6 +38,7 @@ runs:
       COMMIT: ${{ fromJSON( inputs.json ).stats.commit }}
       REFERENCE: ${{ fromJSON( inputs.json ).stats_with_delta.reference_commit }}
       ANNOTATIONS: ${{ fromJSON( inputs.json ).annotations }}
+      JSON: ${{ inputs.json }}
     shell: bash
     run: |
       echo "title=$TITLE"
@@ -53,9 +54,7 @@ runs:
 
       echo
       echo "JSON output:"
-      cat <<EOF
-      ${{ inputs.json }}
-      EOF
+      echo "$JSON"
       echo
 
       if [[ "$CONCLUSION" != "success" ]]

--- a/misc/action/package-downloads/action.yml
+++ b/misc/action/package-downloads/action.yml
@@ -37,9 +37,13 @@ runs:
 
     - name: Get download info
       id: downloads
+      env:
+        SCRIPT_URL: ${{ inputs.url }}
+        SCRIPT_REPO: ${{ inputs.repo }}
+        SCRIPT_PACKAGE: ${{ inputs.package }}
       shell: bash
       run: |
-        python ${{ github.action_path }}/script.py ${{ inputs.url }} ${{ inputs.repo }} ${{ inputs.package }}
+        python "${{ github.action_path }}/script.py" "$SCRIPT_URL" "$SCRIPT_REPO" "$SCRIPT_PACKAGE"
 
 branding:
   icon: 'download-cloud'


### PR DESCRIPTION
…ed inputs

Replace direct ${{ inputs.* }} interpolation in run: blocks with env: indirection. Assign each input to a step-level env var and reference $ENV_VAR in shell commands.

Files changed:
- docker/action.yml: docker_platform, docker_registry, docker_image, docker_tag
- misc/action/json-output/action.yml: inputs.json (heredoc → echo "$JSON")
- misc/action/find-workflows/action.yml: inputs.url, inputs.query
- misc/action/package-downloads/action.yml: inputs.url, inputs.repo, inputs.package

Based on SHA c950f6fb443cb5af20a377fd0dfaa78838901040 (v2.23.0). See upstream EnricoMi/publish-unit-test-result-action#737.